### PR TITLE
Site tier-1: open-set banner, sensitivity selector, bootstrap intervals

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,8 +33,8 @@ dist/
 downloads/
 eggs/
 .eggs/
-lib/
-lib64/
+/lib/
+/lib64/
 parts/
 sdist/
 var/

--- a/.gitignore
+++ b/.gitignore
@@ -33,8 +33,12 @@ dist/
 downloads/
 eggs/
 .eggs/
-/lib/
-/lib64/
+lib/
+lib64/
+# Tracked TypeScript helpers under app/src/lib/ — exempted from the
+# Python-style lib/ blanket ignore above.
+!app/src/lib/
+!app/src/lib/**
 parts/
 sdist/
 var/

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -124,7 +124,11 @@ export default function App() {
 
       <main className="max-w-7xl mx-auto px-4 sm:px-6">
         <section id="models" className="pt-12 pb-16 sm:pt-16 sm:pb-20">
-          <ModelLeaderboard data={data} selectedView={selectedView} />
+          <ModelLeaderboard
+            data={data}
+            selectedView={selectedView}
+            dashboard={dashboard}
+          />
         </section>
 
         {!isGlobal && (

--- a/app/src/app/paper/page.tsx
+++ b/app/src/app/paper/page.tsx
@@ -1,6 +1,10 @@
 /* eslint-disable @next/next/no-img-element */
 import Link from "next/link";
 
+import SiteHeader from "../../components/SiteHeader";
+
+const SNAPSHOT_DATE_LABEL = "Snapshot 2026-05-01";
+
 const manuscriptPaths = {
   pdf: "/paper/policybench.pdf",
   web: "/paper/web/index.html?v=20260501",
@@ -8,63 +12,39 @@ const manuscriptPaths = {
 const ssrnUrl = process.env.NEXT_PUBLIC_POLICYBENCH_SSRN_URL;
 
 export default function PaperPage() {
+  const expanded = (
+    <>
+      <p className="max-w-2xl text-sm leading-relaxed text-text-secondary sm:text-base">
+        Benchmarking no-tool tax-and-benefit estimation in frontier language
+        models. This page embeds the frozen 2026-05-01 manuscript snapshot:
+        a 100-household-per-country public preview scored against
+        PolicyEngine reference outputs.
+      </p>
+      <div className="mt-4 flex flex-wrap items-center gap-3">
+        <span className="inline-flex items-center gap-1.5 rounded-full border border-border bg-card px-2.5 py-1 text-[10px] font-medium uppercase tracking-[0.12em] text-text-secondary">
+          <span aria-hidden className="h-1.5 w-1.5 rounded-full bg-primary/70" />
+          {SNAPSHOT_DATE_LABEL}
+        </span>
+      </div>
+    </>
+  );
+
   return (
     <main className="min-h-screen bg-void">
-      <nav className="sticky top-0 z-40 border-b border-border bg-bg/90 backdrop-blur-md">
-        <div className="mx-auto flex max-w-7xl items-center gap-4 px-4 sm:px-6">
-          <Link
-            href="/"
-            className="shrink-0 py-3 font-[family-name:var(--font-display)] text-lg tracking-tight text-text transition-colors hover:text-primary"
-          >
-            PolicyBench
-          </Link>
-          <div className="min-w-0 flex-1 overflow-x-auto">
-            <div className="flex min-w-max gap-1">
-              <a
-                href="#paper-top"
-                className="border-b-2 border-primary px-3 py-3 text-[11px] font-medium uppercase tracking-wider text-primary sm:px-4"
-              >
-                Paper
-              </a>
-            </div>
-          </div>
-          <div className="flex shrink-0 items-center gap-2">
-            <Link
-              href="/"
-              className="rounded-full border border-border bg-card px-3 py-1.5 text-[11px] font-medium uppercase tracking-wider text-text-secondary transition-colors hover:border-primary/40 hover:text-primary"
-            >
-              Benchmark
-            </Link>
-            <a
-              href="https://policyengine.org"
-              className="inline-flex items-center gap-1.5 rounded-full border border-border bg-card px-2.5 py-1.5 text-[11px] font-medium uppercase tracking-wider text-text-secondary transition-colors hover:border-primary/40 hover:text-primary"
-              aria-label="By PolicyEngine"
-              title="By PolicyEngine"
-            >
-              <span>by</span>
-              <img
-                src="/assets/policyengine-logo.svg"
-                alt="PolicyEngine"
-                className="h-3 w-auto"
-              />
-            </a>
-          </div>
-        </div>
-      </nav>
+      <SiteHeader
+        actionLink={{
+          label: "Benchmark",
+          href: "/",
+          type: "internal",
+        }}
+        expandedContent={expanded}
+        alwaysExpanded
+      />
 
       <div id="paper-top" className="mx-auto max-w-6xl px-4 py-8 sm:px-6">
         <div className="eyebrow mb-3">Manuscript</div>
-        <h1 className="font-[family-name:var(--font-display)] text-4xl tracking-tight text-text sm:text-5xl">
-          PolicyBench
-        </h1>
-        <p className="mt-4 max-w-2xl text-base leading-relaxed text-text-secondary sm:text-lg">
-          Benchmarking no-tool tax-and-benefit estimation in frontier language
-          models. This page embeds the frozen 2026-05-01 manuscript snapshot:
-          a 100-household-per-country public preview scored against
-          PolicyEngine reference outputs.
-        </p>
 
-        <div className="mt-5 inline-flex items-center gap-2 rounded-full border border-border bg-card px-3 py-1.5 text-sm text-text-secondary">
+        <div className="mt-2 inline-flex items-center gap-2 rounded-full border border-border bg-card px-3 py-1.5 text-sm text-text-secondary">
           <img
             src="/assets/policyengine-logo.svg"
             alt="PolicyEngine"
@@ -73,7 +53,7 @@ export default function PaperPage() {
           <span>Research paper by PolicyEngine</span>
         </div>
 
-        <div className="mt-8 flex flex-wrap gap-3">
+        <div className="mt-6 flex flex-wrap gap-3">
           {ssrnUrl && (
             <a
               href={ssrnUrl}

--- a/app/src/components/Hero.tsx
+++ b/app/src/components/Hero.tsx
@@ -1,77 +1,12 @@
-/* eslint-disable @next/next/no-img-element */
-import Link from "next/link";
-import { useEffect, useRef, useState } from "react";
-import { MODEL_LABELS } from "../modelMeta";
 import type {
   BenchData,
   DashboardBundle,
   GlobalBenchData,
   ViewKey,
 } from "../types";
-import { VIEW_LABELS } from "../types";
+import SiteHeader, { type HeaderNavItem } from "./SiteHeader";
 
-function ViewSelector({
-  selectedView,
-  onSelect,
-  views,
-  compact,
-}: {
-  selectedView: ViewKey;
-  onSelect: (view: ViewKey) => void;
-  views: ViewKey[];
-  compact?: boolean;
-}) {
-  const pill = compact
-    ? "rounded-full text-[10px] px-2.5 py-1 font-medium transition-colors"
-    : "rounded-full px-3 py-1.5 text-xs font-medium transition-colors sm:px-4";
-  return (
-    <div className="inline-flex max-w-full items-center gap-1 rounded-full border border-border bg-bg/80 p-1">
-      {views.map((view) => (
-        <button
-          key={view}
-          type="button"
-          onClick={() => onSelect(view)}
-          className={`${pill} ${
-            selectedView === view
-              ? "bg-primary text-void"
-              : "text-text-secondary hover:text-text"
-          }`}
-        >
-          {VIEW_LABELS[view]}
-        </button>
-      ))}
-    </div>
-  );
-}
-
-type NavItem = { id: string; label: string };
-
-/** Returns 0 at top, 1 when fully collapsed. Smooth continuous value. */
-function getScrollProgress(threshold: number) {
-  if (typeof window === "undefined") return 0;
-  return Math.min(1, Math.max(0, window.scrollY / threshold));
-}
-
-function useScrollProgress(threshold = 80) {
-  const [progress, setProgress] = useState(() => getScrollProgress(threshold));
-  const rafRef = useRef(0);
-
-  useEffect(() => {
-    const onScroll = () => {
-      cancelAnimationFrame(rafRef.current);
-      rafRef.current = requestAnimationFrame(() => {
-        setProgress(getScrollProgress(threshold));
-      });
-    };
-    window.addEventListener("scroll", onScroll, { passive: true });
-    return () => {
-      window.removeEventListener("scroll", onScroll);
-      cancelAnimationFrame(rafRef.current);
-    };
-  }, [threshold]);
-
-  return progress;
-}
+const SNAPSHOT_DATE_LABEL = "Snapshot 2026-05-01";
 
 export default function Hero({
   selectedView,
@@ -87,22 +22,21 @@ export default function Hero({
   dashboard: DashboardBundle;
   data: BenchData | GlobalBenchData;
   availableViews: ViewKey[];
-  navItems: readonly NavItem[];
+  navItems: readonly HeaderNavItem[];
   activeNav: string;
 }) {
-  const progress = useScrollProgress(80);
-  const scrolled = progress > 0.5;
-
   const isGlobal = selectedView === "global";
   const benchData = isGlobal ? null : (data as BenchData);
   const rankedNoTools = [...data.modelStats]
     .filter((m) => m.condition === "no_tools")
     .sort((a, b) => b.score - a.score);
-  const leadModel = rankedNoTools[0];
   const countryHouseholds = Object.values(dashboard.countries).map(
-    (country) => Object.keys(country?.scenarios ?? {}).length
+    (country) => Object.keys(country?.scenarios ?? {}).length,
   );
-  const totalHouseholds = countryHouseholds.reduce((sum, count) => sum + count, 0);
+  const totalHouseholds = countryHouseholds.reduce(
+    (sum, count) => sum + count,
+    0,
+  );
   const countryCount = countryHouseholds.length;
 
   const subtitle = isGlobal
@@ -111,183 +45,70 @@ export default function Hero({
 
   const stats = isGlobal
     ? [
-        { value: `${leadModel?.score.toFixed(1) ?? "0.0"}%`, label: "Top score" },
         { value: `${countryCount}`, label: "Countries" },
-        { value: `${(data as GlobalBenchData).sharedModelCount}`, label: "Models" },
-        { value: `${totalHouseholds.toLocaleString()}`, label: "Households" },
+        {
+          value: `${(data as GlobalBenchData).sharedModelCount}`,
+          label: "Models",
+        },
+        {
+          value: `${totalHouseholds.toLocaleString()}`,
+          label: "Households",
+        },
       ]
     : [
-        { value: `${leadModel?.score.toFixed(1) ?? "0.0"}%`, label: "Top score" },
         { value: `${rankedNoTools.length}`, label: "Models" },
-        { value: `${Object.keys(benchData!.scenarios).length.toLocaleString()}`, label: "Households" },
+        {
+          value: `${Object.keys(benchData!.scenarios).length.toLocaleString()}`,
+          label: "Households",
+        },
         { value: `${benchData!.programStats.length}`, label: "Outputs" },
       ];
 
-  // Continuous interpolation helpers
-  const lerp = (a: number, b: number) => a + (b - a) * progress;
-  const expandedPadTop = lerp(40, 8); // pt-10 → py-2
-  const expandedPadBot = lerp(16, 8);
-  const titleSize = lerp(36, 16); // text-4xl → text-base
-  const expandOpacity = 1 - Math.min(1, progress * 2); // fade out faster
-  const expandHeight = `${(1 - progress) * 140}px`;
-  const navOpacity = Math.max(0, (progress - 0.3) / 0.7); // fade in after 30%
-  const bgOpacity = progress;
+  const expanded = (
+    <>
+      <p className="text-text-secondary text-sm sm:text-base max-w-xl leading-relaxed">
+        {subtitle}{" "}
+        <span className="text-text-muted">
+          100% = exact answers across the full benchmark.
+        </span>
+      </p>
+
+      <div className="flex flex-wrap items-center gap-x-6 gap-y-3 mt-4">
+        <div className="flex items-center gap-5 sm:gap-6">
+          {stats.map((stat, i) => (
+            <div key={stat.label} className="flex items-baseline gap-1.5">
+              <span className="font-[family-name:var(--font-mono)] text-lg sm:text-xl font-semibold text-primary tracking-tight">
+                {stat.value}
+              </span>
+              <span className="text-[10px] uppercase tracking-[0.12em] text-text-muted font-medium">
+                {stat.label}
+              </span>
+              {i < stats.length - 1 && (
+                <span className="text-border ml-2 select-none" aria-hidden>
+                  /
+                </span>
+              )}
+            </div>
+          ))}
+        </div>
+
+        <span className="inline-flex items-center gap-1.5 rounded-full border border-border bg-card px-2.5 py-1 text-[10px] font-medium uppercase tracking-[0.12em] text-text-secondary">
+          <span aria-hidden className="h-1.5 w-1.5 rounded-full bg-primary/70" />
+          {SNAPSHOT_DATE_LABEL}
+        </span>
+      </div>
+    </>
+  );
 
   return (
-    <header className="sticky top-0 z-40">
-      {/* Background — fades in */}
-      <div
-        className="absolute inset-0 border-b backdrop-blur-md"
-        style={{
-          opacity: bgOpacity,
-          backgroundColor: `color-mix(in srgb, var(--color-bg) ${Math.round(bgOpacity * 90)}%, transparent)`,
-          borderColor: `color-mix(in srgb, var(--color-border) ${Math.round(bgOpacity * 100)}%, transparent)`,
-        }}
-      />
-
-      {/* Gradient glow — fades out */}
-      <div
-        className="absolute inset-x-0 top-0 h-[280px] bg-[radial-gradient(circle_at_top,_color-mix(in_srgb,var(--color-primary)_13%,transparent),transparent_58%)] pointer-events-none"
-        style={{ opacity: 1 - progress }}
-      />
-
-      <div className="relative max-w-7xl mx-auto px-4 sm:px-6">
-        {/* Top row: brand + nav + view selector */}
-        <div
-          className="flex items-center gap-3"
-          style={{
-            paddingTop: `${expandedPadTop}px`,
-            paddingBottom: `${expandedPadBot}px`,
-          }}
-        >
-          <Link href="/" className="shrink-0 hover:opacity-80">
-            <span
-              className="font-[family-name:var(--font-display)] tracking-tight text-text leading-none"
-              style={{ fontSize: `${titleSize}px` }}
-            >
-              PolicyBench
-            </span>
-          </Link>
-
-          {/* Nav tabs — fade in as you scroll */}
-          <div
-            className="flex items-center overflow-hidden"
-            style={{
-              opacity: navOpacity,
-              maxWidth: navOpacity > 0.05 ? "600px" : "0px",
-              marginLeft: navOpacity > 0.05 ? "4px" : "0px",
-            }}
-          >
-            <div className="h-4 w-px bg-border shrink-0 mx-2" />
-            <div className="flex min-w-max gap-0.5">
-              {navItems.map((item) => (
-                <a
-                  key={item.id}
-                  href={`#${item.id}`}
-                  className={`px-2.5 py-2 text-[11px] font-medium tracking-wider uppercase border-b-2 sm:px-3 ${
-                    activeNav === item.id
-                      ? "border-primary text-primary"
-                      : "border-transparent text-text-secondary hover:text-text"
-                  }`}
-                >
-                  {item.label}
-                </a>
-              ))}
-            </div>
-          </div>
-
-          <div className="flex-1" />
-
-          <ViewSelector
-            selectedView={selectedView}
-            onSelect={onSelectView}
-            views={availableViews}
-            compact={scrolled}
-          />
-
-          {/* Paper link — fades in with nav */}
-          <div
-            className="overflow-hidden"
-            style={{
-              opacity: navOpacity,
-              maxWidth: navOpacity > 0.05 ? "80px" : "0px",
-            }}
-          >
-            <Link
-              href="/paper"
-              className="rounded-full border border-border bg-card px-3 py-1 text-[11px] font-medium uppercase tracking-wider text-text-secondary hover:border-primary/40 hover:text-primary whitespace-nowrap"
-            >
-              Paper
-            </Link>
-          </div>
-
-          <a
-            href="https://policyengine.org"
-            className="inline-flex shrink-0 items-center gap-1.5 rounded-full border border-border bg-card px-2.5 py-1 text-[11px] font-medium uppercase tracking-wider text-text-secondary transition-colors hover:border-primary/40 hover:text-primary"
-            aria-label="By PolicyEngine"
-            title="By PolicyEngine"
-          >
-            <span>by</span>
-            <img
-              src="/assets/policyengine-logo.svg"
-              alt="PolicyEngine"
-              className="h-3 w-auto"
-            />
-          </a>
-        </div>
-
-        {/* Expanded content: subtitle + stats */}
-        <div
-          className="overflow-hidden"
-          style={{
-            maxHeight: expandHeight,
-            opacity: expandOpacity,
-            paddingBottom: expandOpacity > 0.05 ? `${lerp(32, 0)}px` : "0px",
-          }}
-        >
-          <p className="text-text-secondary text-sm sm:text-base max-w-xl leading-relaxed">
-            {subtitle}{" "}
-            <span className="text-text-muted">
-              100% = exact answers across the full benchmark.
-            </span>
-          </p>
-
-          <div className="flex items-center gap-6 mt-4">
-            <div className="flex items-center gap-5 sm:gap-6">
-              {stats.map((stat, i) => (
-                <div key={stat.label} className="flex items-baseline gap-1.5">
-                  <span className="font-[family-name:var(--font-mono)] text-lg sm:text-xl font-semibold text-primary tracking-tight">
-                    {stat.value}
-                  </span>
-                  <span className="text-[10px] uppercase tracking-[0.12em] text-text-muted font-medium">
-                    {stat.label}
-                  </span>
-                  {i < stats.length - 1 && (
-                    <span className="text-border ml-2 select-none" aria-hidden>
-                      /
-                    </span>
-                  )}
-                </div>
-              ))}
-            </div>
-
-            {leadModel && (
-              <div className="hidden sm:flex items-center gap-2 ml-auto text-sm text-text-muted">
-                <span>Leading:</span>
-                <span className="text-text font-medium">
-                  {MODEL_LABELS[leadModel.model] ?? leadModel.model}
-                </span>
-              </div>
-            )}
-          </div>
-        </div>
-      </div>
-
-      {/* Bottom border gradient — fades out */}
-      <div
-        className="h-px bg-gradient-to-r from-transparent via-primary/25 to-transparent"
-        style={{ opacity: 1 - progress }}
-      />
-    </header>
+    <SiteHeader
+      navItems={navItems}
+      activeNav={activeNav}
+      selectedView={selectedView}
+      onSelectView={onSelectView}
+      availableViews={availableViews}
+      actionLink={{ label: "Paper", href: "/paper", type: "internal" }}
+      expandedContent={expanded}
+    />
   );
 }

--- a/app/src/components/ModelLeaderboard.tsx
+++ b/app/src/components/ModelLeaderboard.tsx
@@ -1,6 +1,7 @@
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 import type {
   BenchData,
+  DashboardBundle,
   GlobalBenchData,
   ModelStat,
   ViewKey,
@@ -12,6 +13,13 @@ import {
   getProviderForModel,
 } from "../modelMeta";
 import ProviderMark from "./ProviderMark";
+import {
+  SENSITIVITY_VIEWS,
+  buildAllRows,
+  modelScoresForView,
+  type SensitivityViewId,
+} from "../lib/sensitivity";
+import { bootstrapIntervals, viewToFilter } from "../lib/bootstrap";
 
 function Badge({
   children,
@@ -97,18 +105,50 @@ const PENDING_MODELS: Record<ViewKey, PendingModel[]> = {
 export default function ModelLeaderboard({
   data,
   selectedView,
+  dashboard,
 }: {
   data: BenchData | GlobalBenchData;
   selectedView: ViewKey;
+  dashboard: DashboardBundle;
 }) {
   const isGlobal = selectedView === "global";
-  const noTools = useMemo<ModelStat[]>(
-    () =>
-      data.modelStats
-        .filter((m) => m.condition === "no_tools")
-        .sort((a, b) => b.score - a.score),
-    [data]
-  );
+  const [sensitivityView, setSensitivityView] =
+    useState<SensitivityViewId>("main");
+
+  const allRows = useMemo(() => buildAllRows(dashboard), [dashboard]);
+
+  const sensitivityScores = useMemo(() => {
+    return modelScoresForView(allRows, sensitivityView, selectedView);
+  }, [allRows, sensitivityView, selectedView]);
+
+  const sensitivityScoreByModel = useMemo(() => {
+    const out = new Map<string, number>();
+    for (const entry of sensitivityScores) out.set(entry.model, entry.score);
+    return out;
+  }, [sensitivityScores]);
+
+  const noTools = useMemo<ModelStat[]>(() => {
+    const base = data.modelStats.filter((m) => m.condition === "no_tools");
+    if (sensitivityView === "main") {
+      return [...base].sort((a, b) => b.score - a.score);
+    }
+    // Reorder + replace score with the sensitivity-view score, dropping models
+    // that don't have a score under this slice.
+    return base
+      .filter((m) => sensitivityScoreByModel.has(m.model))
+      .map((m) => ({ ...m, score: sensitivityScoreByModel.get(m.model)! }))
+      .sort((a, b) => b.score - a.score);
+  }, [data, sensitivityView, sensitivityScoreByModel]);
+
+  const intervals = useMemo(() => {
+    return bootstrapIntervals(
+      allRows,
+      selectedView,
+      viewToFilter(sensitivityView),
+      { draws: 400, seed: 42 },
+    );
+  }, [allRows, selectedView, sensitivityView]);
+
   const pendingModels = useMemo<PendingModel[]>(() => {
     const present = new Set(noTools.map((model) => model.model));
     const configured = PENDING_MODELS[selectedView].filter(
@@ -120,6 +160,8 @@ export default function ModelLeaderboard({
       return aIndex - bIndex;
     });
   }, [noTools, selectedView]);
+
+  const activeView = SENSITIVITY_VIEWS.find((v) => v.id === sensitivityView)!;
 
   return (
     <div>
@@ -145,6 +187,53 @@ export default function ModelLeaderboard({
         )}
       </p>
 
+      <div
+        className="mt-5 flex items-start gap-3 rounded-xl border border-warning/15 bg-warning-soft px-4 py-3 text-xs text-text-secondary animate-fade-up"
+        style={{ animationDelay: "180ms" }}
+        role="note"
+      >
+        <span
+          aria-hidden
+          className="mt-0.5 inline-flex h-2 w-2 shrink-0 rounded-full bg-warning"
+        />
+        <p>
+          <strong className="text-text">Open-set leaderboard.</strong> The
+          public scenario explorer exposes prompts and PolicyEngine reference
+          outputs, so future model releases or fine-tunes could learn from the
+          released cases. Treat this as a public preview; protected
+          held-out claims would require a separate rotating evaluation set.
+        </p>
+      </div>
+
+      <div
+        className="mt-5 flex flex-wrap items-center gap-3 animate-fade-up"
+        style={{ animationDelay: "200ms" }}
+      >
+        <span className="text-[10px] font-medium uppercase tracking-[0.14em] text-text-muted">
+          View
+        </span>
+        <div className="inline-flex flex-wrap items-center gap-1 rounded-full border border-border bg-card p-1">
+          {SENSITIVITY_VIEWS.map((view) => (
+            <button
+              key={view.id}
+              type="button"
+              onClick={() => setSensitivityView(view.id)}
+              className={`rounded-full px-3 py-1 text-[11px] font-medium transition-colors ${
+                sensitivityView === view.id
+                  ? "bg-primary text-void"
+                  : "text-text-secondary hover:text-text"
+              }`}
+              title={view.description}
+            >
+              {view.label}
+            </button>
+          ))}
+        </div>
+        <span className="text-[11px] text-text-muted">
+          {activeView.description}
+        </span>
+      </div>
+
       <div className="mt-8 space-y-3">
         <div
           className={`hidden gap-3 px-4 text-[10px] uppercase tracking-[0.14em] text-text-muted font-medium md:grid ${
@@ -167,6 +256,16 @@ export default function ModelLeaderboard({
             m.scoreRunStd,
             m.runCount
           );
+          const interval = intervals.get(m.model);
+          const rankRange =
+            interval && interval.rankLower !== interval.rankUpper
+              ? `Rank ${interval.rankLower}-${interval.rankUpper}`
+              : interval
+                ? `Rank ${interval.rankLower}`
+                : null;
+          const scoreRange = interval
+            ? `${interval.lower.toFixed(1)}-${interval.upper.toFixed(1)}`
+            : null;
           return (
             <div
               key={m.model}
@@ -192,6 +291,11 @@ export default function ModelLeaderboard({
                     {!isGlobal && stabilityLabel && (
                       <div className="mt-1 pl-6 text-[10px] font-[family-name:var(--font-mono)] text-text-muted">
                         {stabilityLabel}
+                      </div>
+                    )}
+                    {rankRange && (
+                      <div className="mt-1 pl-6 text-[10px] font-[family-name:var(--font-mono)] text-text-muted">
+                        {rankRange} · 95% {scoreRange}
                       </div>
                     )}
                   </div>
@@ -235,6 +339,14 @@ export default function ModelLeaderboard({
                   <Badge variant={accColor(m.score)}>
                     {m.score.toFixed(1)}%
                   </Badge>
+                  {rankRange && (
+                    <div
+                      className="text-[10px] text-text-muted font-[family-name:var(--font-mono)] mt-1"
+                      title="Household-resampling 95% interval (400 draws, seed 42)"
+                    >
+                      {rankRange} · 95% {scoreRange}
+                    </div>
+                  )}
                   {!isGlobal && stabilityLabel && (
                     <div className="text-[10px] text-text-muted font-[family-name:var(--font-mono)] mt-1">
                       {stabilityLabel}

--- a/app/src/components/ModelLeaderboard.tsx
+++ b/app/src/components/ModelLeaderboard.tsx
@@ -17,9 +17,14 @@ import {
   SENSITIVITY_VIEWS,
   buildAllRows,
   modelScoresForView,
+  viewSupportsGlobal,
   type SensitivityViewId,
 } from "../lib/sensitivity";
-import { bootstrapIntervals, viewToFilter } from "../lib/bootstrap";
+import {
+  DEFAULT_DRAWS,
+  bootstrapIntervals,
+  viewToFilter,
+} from "../lib/bootstrap";
 
 function Badge({
   children,
@@ -117,9 +122,24 @@ export default function ModelLeaderboard({
 
   const allRows = useMemo(() => buildAllRows(dashboard), [dashboard]);
 
+  // Some sensitivity slices have no rows in one country (e.g. "Binary only"
+  // has zero UK rows). In that case the global view cannot be a true
+  // cross-country score; fall back to the canonical Main view so the global
+  // tab still has a defensible ranking and surface a notice on the leaderboard.
+  const globalUnsupportedForView = useMemo(
+    () =>
+      isGlobal &&
+      sensitivityView !== "main" &&
+      !viewSupportsGlobal(allRows, sensitivityView),
+    [allRows, isGlobal, sensitivityView],
+  );
+  const effectiveView: SensitivityViewId = globalUnsupportedForView
+    ? "main"
+    : sensitivityView;
+
   const sensitivityScores = useMemo(() => {
-    return modelScoresForView(allRows, sensitivityView, selectedView);
-  }, [allRows, sensitivityView, selectedView]);
+    return modelScoresForView(allRows, effectiveView, selectedView);
+  }, [allRows, effectiveView, selectedView]);
 
   const sensitivityScoreByModel = useMemo(() => {
     const out = new Map<string, number>();
@@ -129,7 +149,7 @@ export default function ModelLeaderboard({
 
   const noTools = useMemo<ModelStat[]>(() => {
     const base = data.modelStats.filter((m) => m.condition === "no_tools");
-    if (sensitivityView === "main") {
+    if (effectiveView === "main") {
       return [...base].sort((a, b) => b.score - a.score);
     }
     // Reorder + replace score with the sensitivity-view score, dropping models
@@ -138,16 +158,16 @@ export default function ModelLeaderboard({
       .filter((m) => sensitivityScoreByModel.has(m.model))
       .map((m) => ({ ...m, score: sensitivityScoreByModel.get(m.model)! }))
       .sort((a, b) => b.score - a.score);
-  }, [data, sensitivityView, sensitivityScoreByModel]);
+  }, [data, effectiveView, sensitivityScoreByModel]);
 
   const intervals = useMemo(() => {
     return bootstrapIntervals(
       allRows,
       selectedView,
-      viewToFilter(sensitivityView),
-      { draws: 400, seed: 42 },
+      viewToFilter(effectiveView),
+      { draws: DEFAULT_DRAWS, seed: 42 },
     );
-  }, [allRows, selectedView, sensitivityView]);
+  }, [allRows, selectedView, effectiveView]);
 
   const pendingModels = useMemo<PendingModel[]>(() => {
     const present = new Set(noTools.map((model) => model.model));
@@ -209,30 +229,64 @@ export default function ModelLeaderboard({
         className="mt-5 flex flex-wrap items-center gap-3 animate-fade-up"
         style={{ animationDelay: "200ms" }}
       >
-        <span className="text-[10px] font-medium uppercase tracking-[0.14em] text-text-muted">
+        <span
+          id="leaderboard-view-label"
+          className="text-[10px] font-medium uppercase tracking-[0.14em] text-text-muted"
+        >
           View
         </span>
-        <div className="inline-flex flex-wrap items-center gap-1 rounded-full border border-border bg-card p-1">
-          {SENSITIVITY_VIEWS.map((view) => (
-            <button
-              key={view.id}
-              type="button"
-              onClick={() => setSensitivityView(view.id)}
-              className={`rounded-full px-3 py-1 text-[11px] font-medium transition-colors ${
-                sensitivityView === view.id
-                  ? "bg-primary text-void"
-                  : "text-text-secondary hover:text-text"
-              }`}
-              title={view.description}
-            >
-              {view.label}
-            </button>
-          ))}
+        <div
+          role="group"
+          aria-labelledby="leaderboard-view-label"
+          className="inline-flex flex-wrap items-center gap-1 rounded-full border border-border bg-card p-1"
+        >
+          {SENSITIVITY_VIEWS.map((view) => {
+            const isActive = sensitivityView === view.id;
+            const disabledForGlobal =
+              isGlobal &&
+              view.id !== "main" &&
+              !viewSupportsGlobal(allRows, view.id);
+            return (
+              <button
+                key={view.id}
+                type="button"
+                onClick={() => setSensitivityView(view.id)}
+                aria-pressed={isActive}
+                aria-disabled={disabledForGlobal || undefined}
+                className={`rounded-full px-3 py-1 text-[11px] font-medium transition-colors ${
+                  isActive
+                    ? "bg-primary text-void"
+                    : disabledForGlobal
+                      ? "text-text-muted opacity-60"
+                      : "text-text-secondary hover:text-text"
+                }`}
+                title={
+                  disabledForGlobal
+                    ? `${view.description} (not available for the Global view; switch to US or UK)`
+                    : view.description
+                }
+              >
+                {view.label}
+              </button>
+            );
+          })}
         </div>
         <span className="text-[11px] text-text-muted">
           {activeView.description}
         </span>
       </div>
+      {globalUnsupportedForView && (
+        <p
+          role="note"
+          className="mt-3 text-[11px] text-text-muted animate-fade-up"
+          style={{ animationDelay: "220ms" }}
+        >
+          The {activeView.label.toLowerCase()} slice has no rows in at least
+          one country, so the global ranking falls back to the Main view.
+          Switch to United States or United Kingdom to see this slice on a
+          single country.
+        </p>
+      )}
 
       <div className="mt-8 space-y-3">
         <div

--- a/app/src/components/ModelLeaderboard.tsx
+++ b/app/src/components/ModelLeaderboard.tsx
@@ -250,13 +250,9 @@ export default function ModelLeaderboard({
               <button
                 key={view.id}
                 type="button"
-                onClick={
-                  disabledForGlobal
-                    ? undefined
-                    : () => setSensitivityView(view.id)
-                }
+                disabled={disabledForGlobal}
+                onClick={() => setSensitivityView(view.id)}
                 aria-pressed={isActive && !disabledForGlobal}
-                aria-disabled={disabledForGlobal || undefined}
                 className={`rounded-full px-3 py-1 text-[11px] font-medium transition-colors ${
                   isActive && !disabledForGlobal
                     ? "bg-primary text-void"

--- a/app/src/components/ModelLeaderboard.tsx
+++ b/app/src/components/ModelLeaderboard.tsx
@@ -250,14 +250,18 @@ export default function ModelLeaderboard({
               <button
                 key={view.id}
                 type="button"
-                onClick={() => setSensitivityView(view.id)}
-                aria-pressed={isActive}
+                onClick={
+                  disabledForGlobal
+                    ? undefined
+                    : () => setSensitivityView(view.id)
+                }
+                aria-pressed={isActive && !disabledForGlobal}
                 aria-disabled={disabledForGlobal || undefined}
                 className={`rounded-full px-3 py-1 text-[11px] font-medium transition-colors ${
-                  isActive
+                  isActive && !disabledForGlobal
                     ? "bg-primary text-void"
                     : disabledForGlobal
-                      ? "text-text-muted opacity-60"
+                      ? "cursor-not-allowed text-text-muted opacity-60"
                       : "text-text-secondary hover:text-text"
                 }`}
                 title={
@@ -281,7 +285,7 @@ export default function ModelLeaderboard({
           className="mt-3 text-[11px] text-text-muted animate-fade-up"
           style={{ animationDelay: "220ms" }}
         >
-          The {activeView.label.toLowerCase()} slice has no rows in at least
+          The &ldquo;{activeView.label}&rdquo; slice has no rows in at least
           one country, so the global ranking falls back to the Main view.
           Switch to United States or United Kingdom to see this slice on a
           single country.

--- a/app/src/components/SiteHeader.tsx
+++ b/app/src/components/SiteHeader.tsx
@@ -1,0 +1,260 @@
+/* eslint-disable @next/next/no-img-element */
+"use client";
+
+import Link from "next/link";
+import { useEffect, useRef, useState } from "react";
+
+import type { ViewKey } from "../types";
+import { VIEW_LABELS } from "../types";
+
+export type HeaderNavItem = { id: string; label: string };
+
+export type HeaderActionLink = {
+  label: string;
+  href: string;
+  type?: "internal" | "external";
+};
+
+function ViewSelector({
+  selectedView,
+  onSelect,
+  views,
+  compact,
+}: {
+  selectedView: ViewKey;
+  onSelect: (view: ViewKey) => void;
+  views: ViewKey[];
+  compact?: boolean;
+}) {
+  const pill = compact
+    ? "rounded-full text-[10px] px-2.5 py-1 font-medium transition-colors"
+    : "rounded-full px-3 py-1.5 text-xs font-medium transition-colors sm:px-4";
+  return (
+    <div className="inline-flex max-w-full items-center gap-1 rounded-full border border-border bg-bg/80 p-1">
+      {views.map((view) => (
+        <button
+          key={view}
+          type="button"
+          onClick={() => onSelect(view)}
+          className={`${pill} ${
+            selectedView === view
+              ? "bg-primary text-void"
+              : "text-text-secondary hover:text-text"
+          }`}
+        >
+          {VIEW_LABELS[view]}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+function getScrollProgress(threshold: number) {
+  if (typeof window === "undefined") return 0;
+  return Math.min(1, Math.max(0, window.scrollY / threshold));
+}
+
+function useScrollProgress(threshold = 80) {
+  const [progress, setProgress] = useState(() => getScrollProgress(threshold));
+  const rafRef = useRef(0);
+
+  useEffect(() => {
+    const onScroll = () => {
+      cancelAnimationFrame(rafRef.current);
+      rafRef.current = requestAnimationFrame(() => {
+        setProgress(getScrollProgress(threshold));
+      });
+    };
+    window.addEventListener("scroll", onScroll, { passive: true });
+    return () => {
+      window.removeEventListener("scroll", onScroll);
+      cancelAnimationFrame(rafRef.current);
+    };
+  }, [threshold]);
+
+  return progress;
+}
+
+export type SiteHeaderProps = {
+  navItems?: readonly HeaderNavItem[];
+  activeNav?: string;
+  selectedView?: ViewKey;
+  onSelectView?: (view: ViewKey) => void;
+  availableViews?: ViewKey[];
+  actionLink?: HeaderActionLink;
+  expandedContent?: React.ReactNode;
+  /**
+   * When true, the header always renders in its expanded state. Used on pages
+   * (e.g. /paper) where we don't have an in-page hero to drive the collapse.
+   */
+  alwaysExpanded?: boolean;
+};
+
+export default function SiteHeader({
+  navItems = [],
+  activeNav,
+  selectedView,
+  onSelectView,
+  availableViews,
+  actionLink,
+  expandedContent,
+  alwaysExpanded = false,
+}: SiteHeaderProps) {
+  const measuredProgress = useScrollProgress(80);
+  const progress = alwaysExpanded ? 0 : measuredProgress;
+  const scrolled = progress > 0.5;
+
+  const lerp = (a: number, b: number) => a + (b - a) * progress;
+  const expandedPadTop = lerp(40, 8);
+  const expandedPadBot = lerp(16, 8);
+  const titleSize = lerp(36, 16);
+  const expandOpacity = 1 - Math.min(1, progress * 2);
+  const expandHeight = `${(1 - progress) * 320}px`;
+  const navOpacity = Math.max(0, (progress - 0.3) / 0.7);
+  const bgOpacity = progress;
+
+  const showViewSelector =
+    availableViews && availableViews.length > 0 && selectedView && onSelectView;
+
+  return (
+    <header className="sticky top-0 z-40">
+      <div
+        className="absolute inset-0 border-b backdrop-blur-md"
+        style={{
+          opacity: alwaysExpanded ? 1 : bgOpacity,
+          backgroundColor: alwaysExpanded
+            ? "color-mix(in srgb, var(--color-bg) 90%, transparent)"
+            : `color-mix(in srgb, var(--color-bg) ${Math.round(bgOpacity * 90)}%, transparent)`,
+          borderColor: alwaysExpanded
+            ? "var(--color-border)"
+            : `color-mix(in srgb, var(--color-border) ${Math.round(bgOpacity * 100)}%, transparent)`,
+        }}
+      />
+
+      <div
+        className="absolute inset-x-0 top-0 h-[280px] bg-[radial-gradient(circle_at_top,_color-mix(in_srgb,var(--color-primary)_13%,transparent),transparent_58%)] pointer-events-none"
+        style={{ opacity: alwaysExpanded ? 1 : 1 - progress }}
+      />
+
+      <div className="relative max-w-7xl mx-auto px-4 sm:px-6">
+        <div
+          className="flex items-center gap-3"
+          style={{
+            paddingTop: `${expandedPadTop}px`,
+            paddingBottom: `${expandedPadBot}px`,
+          }}
+        >
+          <Link href="/" className="shrink-0 hover:opacity-80">
+            <span
+              className="font-[family-name:var(--font-display)] tracking-tight text-text leading-none"
+              style={{ fontSize: `${titleSize}px` }}
+            >
+              PolicyBench
+            </span>
+          </Link>
+
+          {navItems.length > 0 && (
+            <div
+              className="flex items-center overflow-hidden"
+              style={{
+                opacity: navOpacity,
+                maxWidth: navOpacity > 0.05 ? "600px" : "0px",
+                marginLeft: navOpacity > 0.05 ? "4px" : "0px",
+              }}
+            >
+              <div className="h-4 w-px bg-border shrink-0 mx-2" />
+              <div className="flex min-w-max gap-0.5">
+                {navItems.map((item) => (
+                  <a
+                    key={item.id}
+                    href={`#${item.id}`}
+                    className={`px-2.5 py-2 text-[11px] font-medium tracking-wider uppercase border-b-2 sm:px-3 ${
+                      activeNav === item.id
+                        ? "border-primary text-primary"
+                        : "border-transparent text-text-secondary hover:text-text"
+                    }`}
+                  >
+                    {item.label}
+                  </a>
+                ))}
+              </div>
+            </div>
+          )}
+
+          <div className="flex-1" />
+
+          {showViewSelector && (
+            <ViewSelector
+              selectedView={selectedView}
+              onSelect={onSelectView}
+              views={availableViews}
+              compact={scrolled}
+            />
+          )}
+
+          {actionLink && (
+            <div
+              className="overflow-hidden"
+              style={{
+                opacity: alwaysExpanded ? 1 : navOpacity,
+                maxWidth:
+                  alwaysExpanded || navOpacity > 0.05 ? "120px" : "0px",
+              }}
+            >
+              {actionLink.type === "external" ? (
+                <a
+                  href={actionLink.href}
+                  className="rounded-full border border-border bg-card px-3 py-1 text-[11px] font-medium uppercase tracking-wider text-text-secondary hover:border-primary/40 hover:text-primary whitespace-nowrap"
+                >
+                  {actionLink.label}
+                </a>
+              ) : (
+                <Link
+                  href={actionLink.href}
+                  className="rounded-full border border-border bg-card px-3 py-1 text-[11px] font-medium uppercase tracking-wider text-text-secondary hover:border-primary/40 hover:text-primary whitespace-nowrap"
+                >
+                  {actionLink.label}
+                </Link>
+              )}
+            </div>
+          )}
+
+          <a
+            href="https://policyengine.org"
+            className="inline-flex shrink-0 items-center gap-1.5 rounded-full border border-border bg-card px-2.5 py-1 text-[11px] font-medium uppercase tracking-wider text-text-secondary transition-colors hover:border-primary/40 hover:text-primary"
+            aria-label="By PolicyEngine"
+            title="By PolicyEngine"
+          >
+            <span>by</span>
+            <img
+              src="/assets/policyengine-logo.svg"
+              alt="PolicyEngine"
+              className="h-3 w-auto"
+            />
+          </a>
+        </div>
+
+        {expandedContent && (
+          <div
+            className="overflow-hidden"
+            style={{
+              maxHeight: alwaysExpanded ? "none" : expandHeight,
+              opacity: alwaysExpanded ? 1 : expandOpacity,
+              paddingBottom:
+                alwaysExpanded || expandOpacity > 0.05
+                  ? `${alwaysExpanded ? 32 : lerp(32, 0)}px`
+                  : "0px",
+            }}
+          >
+            {expandedContent}
+          </div>
+        )}
+      </div>
+
+      <div
+        className="h-px bg-gradient-to-r from-transparent via-primary/25 to-transparent"
+        style={{ opacity: alwaysExpanded ? 1 : 1 - progress }}
+      />
+    </header>
+  );
+}

--- a/app/src/components/SiteHeader.tsx
+++ b/app/src/components/SiteHeader.tsx
@@ -30,12 +30,17 @@ function ViewSelector({
     ? "rounded-full text-[10px] px-2.5 py-1 font-medium transition-colors"
     : "rounded-full px-3 py-1.5 text-xs font-medium transition-colors sm:px-4";
   return (
-    <div className="inline-flex max-w-full items-center gap-1 rounded-full border border-border bg-bg/80 p-1">
+    <div
+      role="group"
+      aria-label="Country view"
+      className="inline-flex max-w-full items-center gap-1 rounded-full border border-border bg-bg/80 p-1"
+    >
       {views.map((view) => (
         <button
           key={view}
           type="button"
           onClick={() => onSelect(view)}
+          aria-pressed={selectedView === view}
           className={`${pill} ${
             selectedView === view
               ? "bg-primary text-void"
@@ -54,11 +59,14 @@ function getScrollProgress(threshold: number) {
   return Math.min(1, Math.max(0, window.scrollY / threshold));
 }
 
-function useScrollProgress(threshold = 80) {
-  const [progress, setProgress] = useState(() => getScrollProgress(threshold));
+function useScrollProgress(threshold = 80, enabled = true) {
+  const [progress, setProgress] = useState(() =>
+    enabled ? getScrollProgress(threshold) : 0,
+  );
   const rafRef = useRef(0);
 
   useEffect(() => {
+    if (!enabled) return;
     const onScroll = () => {
       cancelAnimationFrame(rafRef.current);
       rafRef.current = requestAnimationFrame(() => {
@@ -70,9 +78,9 @@ function useScrollProgress(threshold = 80) {
       window.removeEventListener("scroll", onScroll);
       cancelAnimationFrame(rafRef.current);
     };
-  }, [threshold]);
+  }, [threshold, enabled]);
 
-  return progress;
+  return enabled ? progress : 0;
 }
 
 export type SiteHeaderProps = {
@@ -100,9 +108,13 @@ export default function SiteHeader({
   expandedContent,
   alwaysExpanded = false,
 }: SiteHeaderProps) {
-  const measuredProgress = useScrollProgress(80);
+  const measuredProgress = useScrollProgress(80, !alwaysExpanded);
   const progress = alwaysExpanded ? 0 : measuredProgress;
   const scrolled = progress > 0.5;
+  const navVisible = !alwaysExpanded; // navItems are only meaningful while
+  // the in-page hero is driving the collapse; on alwaysExpanded pages we
+  // hide them outright by leaving navItems empty.
+  const actionVisible = alwaysExpanded || progress > 0.3;
 
   const lerp = (a: number, b: number) => a + (b - a) * progress;
   const expandedPadTop = lerp(40, 8);
@@ -161,6 +173,7 @@ export default function SiteHeader({
                 maxWidth: navOpacity > 0.05 ? "600px" : "0px",
                 marginLeft: navOpacity > 0.05 ? "4px" : "0px",
               }}
+              aria-hidden={navVisible ? undefined : true}
             >
               <div className="h-4 w-px bg-border shrink-0 mx-2" />
               <div className="flex min-w-max gap-0.5">
@@ -168,6 +181,7 @@ export default function SiteHeader({
                   <a
                     key={item.id}
                     href={`#${item.id}`}
+                    tabIndex={navVisible ? 0 : -1}
                     className={`px-2.5 py-2 text-[11px] font-medium tracking-wider uppercase border-b-2 sm:px-3 ${
                       activeNav === item.id
                         ? "border-primary text-primary"
@@ -200,10 +214,12 @@ export default function SiteHeader({
                 maxWidth:
                   alwaysExpanded || navOpacity > 0.05 ? "120px" : "0px",
               }}
+              aria-hidden={actionVisible ? undefined : true}
             >
               {actionLink.type === "external" ? (
                 <a
                   href={actionLink.href}
+                  tabIndex={actionVisible ? 0 : -1}
                   className="rounded-full border border-border bg-card px-3 py-1 text-[11px] font-medium uppercase tracking-wider text-text-secondary hover:border-primary/40 hover:text-primary whitespace-nowrap"
                 >
                   {actionLink.label}
@@ -211,6 +227,7 @@ export default function SiteHeader({
               ) : (
                 <Link
                   href={actionLink.href}
+                  tabIndex={actionVisible ? 0 : -1}
                   className="rounded-full border border-border bg-card px-3 py-1 text-[11px] font-medium uppercase tracking-wider text-text-secondary hover:border-primary/40 hover:text-primary whitespace-nowrap"
                 >
                   {actionLink.label}

--- a/app/src/components/SiteHeader.tsx
+++ b/app/src/components/SiteHeader.tsx
@@ -111,9 +111,11 @@ export default function SiteHeader({
   const measuredProgress = useScrollProgress(80, !alwaysExpanded);
   const progress = alwaysExpanded ? 0 : measuredProgress;
   const scrolled = progress > 0.5;
-  const navVisible = !alwaysExpanded; // navItems are only meaningful while
-  // the in-page hero is driving the collapse; on alwaysExpanded pages we
-  // hide them outright by leaving navItems empty.
+  const navOpacity = Math.max(0, (progress - 0.3) / 0.7);
+  // The collapsed nav has opacity:0 / max-width:0 until the user has scrolled
+  // past ~30% of the threshold; tie keyboard focus to the same gate so the
+  // links don't sit invisible-but-tabbable in the home-page tab order.
+  const navVisible = !alwaysExpanded && navOpacity > 0.05;
   const actionVisible = alwaysExpanded || progress > 0.3;
 
   const lerp = (a: number, b: number) => a + (b - a) * progress;
@@ -122,7 +124,6 @@ export default function SiteHeader({
   const titleSize = lerp(36, 16);
   const expandOpacity = 1 - Math.min(1, progress * 2);
   const expandHeight = `${(1 - progress) * 320}px`;
-  const navOpacity = Math.max(0, (progress - 0.3) / 0.7);
   const bgOpacity = progress;
 
   const showViewSelector =

--- a/app/src/lib/bootstrap.ts
+++ b/app/src/lib/bootstrap.ts
@@ -1,0 +1,201 @@
+import type { CountryCode, ViewKey } from "../types";
+import type { ScoreRow } from "./scoring";
+import { type SensitivityViewId } from "./sensitivity";
+
+const DEFAULT_DRAWS = 500;
+
+function mulberry32(seed: number): () => number {
+  let state = seed >>> 0;
+  return () => {
+    state = (state + 0x6d2b79f5) >>> 0;
+    let t = state;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+type ModelScenarioOutputBuckets = Map<
+  string, // model
+  Map<
+    CountryCode,
+    Map<
+      string, // scenarioId
+      Map<string, { sum: number; count: number }> // outputGroup -> sum/count
+    >
+  >
+>;
+
+function bucketize(rows: ScoreRow[]): ModelScenarioOutputBuckets {
+  const buckets: ModelScenarioOutputBuckets = new Map();
+  for (const row of rows) {
+    let countryMap = buckets.get(row.model);
+    if (!countryMap) {
+      countryMap = new Map();
+      buckets.set(row.model, countryMap);
+    }
+    let scenarioMap = countryMap.get(row.country);
+    if (!scenarioMap) {
+      scenarioMap = new Map();
+      countryMap.set(row.country, scenarioMap);
+    }
+    let outputMap = scenarioMap.get(row.scenarioId);
+    if (!outputMap) {
+      outputMap = new Map();
+      scenarioMap.set(row.scenarioId, outputMap);
+    }
+    const cur = outputMap.get(row.outputGroup) ?? { sum: 0, count: 0 };
+    cur.sum += row.score * 100;
+    cur.count += 1;
+    outputMap.set(row.outputGroup, cur);
+  }
+  return buckets;
+}
+
+export type BootstrapInterval = {
+  lower: number;
+  upper: number;
+  rankLower: number;
+  rankUpper: number;
+};
+
+export function bootstrapIntervals(
+  rows: ScoreRow[],
+  selectedView: ViewKey,
+  filterFn: (row: ScoreRow) => boolean,
+  options: { draws?: number; seed?: number } = {},
+): Map<string, BootstrapInterval> {
+  const draws = options.draws ?? DEFAULT_DRAWS;
+  const seed = options.seed ?? 42;
+  const filtered = rows.filter(filterFn);
+  const buckets = bucketize(filtered);
+
+  // Per-country scenario universe.
+  const perCountryScenarios = new Map<CountryCode, string[]>();
+  for (const countryMap of buckets.values()) {
+    for (const [country, scenarioMap] of countryMap) {
+      const list = perCountryScenarios.get(country) ?? [];
+      for (const scenarioId of scenarioMap.keys()) {
+        if (!list.includes(scenarioId)) list.push(scenarioId);
+      }
+      perCountryScenarios.set(country, list);
+    }
+  }
+  for (const list of perCountryScenarios.values()) list.sort();
+
+  const countriesToUse: CountryCode[] =
+    selectedView === "global"
+      ? (["us", "uk"] as CountryCode[]).filter((c) =>
+          perCountryScenarios.has(c),
+        )
+      : [selectedView as CountryCode];
+
+  const models = [...buckets.keys()];
+  const rng = mulberry32(seed);
+
+  const drawScores: Record<string, number[]> = {};
+  for (const model of models) drawScores[model] = [];
+  const rankSamples: Record<string, number[]> = {};
+  for (const model of models) rankSamples[model] = [];
+
+  for (let draw = 0; draw < draws; draw += 1) {
+    // Sample scenario ids per country with replacement.
+    const sampledIds = new Map<CountryCode, string[]>();
+    for (const country of countriesToUse) {
+      const ids = perCountryScenarios.get(country);
+      if (!ids || ids.length === 0) continue;
+      const sampled: string[] = [];
+      for (let i = 0; i < ids.length; i += 1) {
+        sampled.push(ids[Math.floor(rng() * ids.length)]);
+      }
+      sampledIds.set(country, sampled);
+    }
+
+    const scoreThisDraw: Record<string, number> = {};
+    for (const model of models) {
+      const countryMap = buckets.get(model)!;
+      const countryScores: number[] = [];
+      for (const country of countriesToUse) {
+        const scenarioMap = countryMap.get(country);
+        if (!scenarioMap) continue;
+        const sampled = sampledIds.get(country) ?? [];
+        // Aggregate output-group means across the sampled scenarios.
+        const outputBuckets = new Map<string, { sum: number; count: number }>();
+        for (const scenarioId of sampled) {
+          const outputMap = scenarioMap.get(scenarioId);
+          if (!outputMap) continue;
+          for (const [outputGroup, v] of outputMap) {
+            const cur = outputBuckets.get(outputGroup) ?? {
+              sum: 0,
+              count: 0,
+            };
+            // Each scenario contributes its mean for that output_group.
+            cur.sum += v.sum / v.count;
+            cur.count += 1;
+            outputBuckets.set(outputGroup, cur);
+          }
+        }
+        if (outputBuckets.size === 0) continue;
+        let totalGroupMean = 0;
+        let groupCount = 0;
+        for (const v of outputBuckets.values()) {
+          if (v.count === 0) continue;
+          totalGroupMean += v.sum / v.count;
+          groupCount += 1;
+        }
+        if (groupCount > 0) countryScores.push(totalGroupMean / groupCount);
+      }
+      if (countryScores.length === countriesToUse.length) {
+        scoreThisDraw[model] =
+          countryScores.reduce((a, b) => a + b, 0) / countryScores.length;
+      }
+    }
+
+    const ranked = Object.entries(scoreThisDraw).sort(
+      (a, b) => b[1] - a[1],
+    );
+    for (let i = 0; i < ranked.length; i += 1) {
+      const [model, score] = ranked[i];
+      drawScores[model].push(score);
+      rankSamples[model].push(i + 1);
+    }
+  }
+
+  const out = new Map<string, BootstrapInterval>();
+  for (const model of models) {
+    const scores = drawScores[model].sort((a, b) => a - b);
+    const ranks = rankSamples[model];
+    if (scores.length === 0) continue;
+    const lowerIndex = Math.floor(scores.length * 0.025);
+    const upperIndex = Math.min(
+      scores.length - 1,
+      Math.ceil(scores.length * 0.975) - 1,
+    );
+    out.set(model, {
+      lower: scores[lowerIndex],
+      upper: scores[upperIndex],
+      rankLower: Math.min(...ranks),
+      rankUpper: Math.max(...ranks),
+    });
+  }
+  return out;
+}
+
+export function viewToFilter(
+  view: SensitivityViewId,
+): (row: ScoreRow) => boolean {
+  switch (view) {
+    case "main":
+      return () => true;
+    case "amount_only":
+      return (row) => row.metricType === "amount";
+    case "binary_only":
+      return (row) => row.metricType === "binary";
+    case "positive_only":
+      return (row) => row.truth !== 0;
+    case "zero_only":
+      return (row) => row.truth === 0;
+    default:
+      return () => true;
+  }
+}

--- a/app/src/lib/bootstrap.ts
+++ b/app/src/lib/bootstrap.ts
@@ -2,7 +2,8 @@ import type { CountryCode, ViewKey } from "../types";
 import type { ScoreRow } from "./scoring";
 import { type SensitivityViewId } from "./sensitivity";
 
-const DEFAULT_DRAWS = 500;
+export const DEFAULT_DRAWS = 400;
+const GLOBAL_REQUIRED_COUNTRIES: readonly CountryCode[] = ["us", "uk"];
 
 function mulberry32(seed: number): () => number {
   let state = seed >>> 0;
@@ -83,12 +84,21 @@ export function bootstrapIntervals(
   }
   for (const list of perCountryScenarios.values()) list.sort();
 
-  const countriesToUse: CountryCode[] =
-    selectedView === "global"
-      ? (["us", "uk"] as CountryCode[]).filter((c) =>
-          perCountryScenarios.has(c),
-        )
-      : [selectedView as CountryCode];
+  // For the global view, only return intervals when every required country
+  // has rows under the active sensitivity slice. Otherwise return an empty
+  // map so the leaderboard component can suppress or relabel the global view
+  // rather than silently presenting a single-country score under a global
+  // banner.
+  let countriesToUse: CountryCode[];
+  if (selectedView === "global") {
+    const haveAllRequired = GLOBAL_REQUIRED_COUNTRIES.every((c) =>
+      perCountryScenarios.has(c),
+    );
+    if (!haveAllRequired) return new Map();
+    countriesToUse = [...GLOBAL_REQUIRED_COUNTRIES];
+  } else {
+    countriesToUse = [selectedView as CountryCode];
+  }
 
   const models = [...buckets.keys()];
   const rng = mulberry32(seed);
@@ -119,7 +129,11 @@ export function bootstrapIntervals(
         const scenarioMap = countryMap.get(country);
         if (!scenarioMap) continue;
         const sampled = sampledIds.get(country) ?? [];
-        // Aggregate output-group means across the sampled scenarios.
+        // Aggregate row-level scores per output group across the sampled
+        // scenarios. We add the bucket sums and counts directly so each row
+        // (e.g. each person-expanded medicaid_eligible row) contributes to
+        // the output-group mean with equal weight, matching the headline
+        // estimator in modelScoresForView.
         const outputBuckets = new Map<string, { sum: number; count: number }>();
         for (const scenarioId of sampled) {
           const outputMap = scenarioMap.get(scenarioId);
@@ -129,9 +143,8 @@ export function bootstrapIntervals(
               sum: 0,
               count: 0,
             };
-            // Each scenario contributes its mean for that output_group.
-            cur.sum += v.sum / v.count;
-            cur.count += 1;
+            cur.sum += v.sum;
+            cur.count += v.count;
             outputBuckets.set(outputGroup, cur);
           }
         }

--- a/app/src/lib/scoring.ts
+++ b/app/src/lib/scoring.ts
@@ -1,0 +1,100 @@
+import { isBinaryVariable, type CountryCode } from "../types";
+
+export type ScoreRow = {
+  country: CountryCode;
+  scenarioId: string;
+  variable: string;
+  outputGroup: string;
+  model: string;
+  truth: number;
+  prediction: number | null | undefined;
+  metricType: "amount" | "binary";
+  score: number;
+};
+
+const PERSON_OUTPUT_PREFIXES = [
+  "head",
+  "spouse",
+  "adult1",
+  "adult2",
+  "adult3",
+  "adult4",
+  "adult5",
+  "child1",
+  "child2",
+  "child3",
+  "child4",
+  "child5",
+  "dependent1",
+  "dependent2",
+  "dependent3",
+] as const;
+
+const PERSON_OUTPUT_SUFFIXES = [
+  "wic",
+  "medicaid",
+  "chip",
+  "medicare",
+  "head_start",
+  "early_head_start",
+] as const;
+
+export function outputGroupForVariable(variable: string): string {
+  const match = variable.match(
+    /^(head|spouse|adult\d+|child\d+|dependent\d+)_(wic|medicaid|chip|medicare|head_start|early_head_start)_eligible$/,
+  );
+  if (match) {
+    return `person_${match[2]}_eligible`;
+  }
+  // Already grouped or not a person-expanded variable.
+  return variable;
+}
+
+export function metricTypeForVariable(
+  variable: string,
+  country: CountryCode,
+): "amount" | "binary" {
+  if (isBinaryVariable(variable, country)) return "binary";
+  const match = variable.match(
+    /^(head|spouse|adult\d+|child\d+|dependent\d+)_(wic|medicaid|chip|medicare|head_start|early_head_start)_eligible$/,
+  );
+  if (match) return "binary";
+  return "amount";
+}
+
+function within(truth: number, prediction: number, tolerance: number): number {
+  if (truth === 0) {
+    return Math.abs(prediction) <= 1.0 ? 1 : 0;
+  }
+  return Math.abs(prediction - truth) / Math.abs(truth) <= tolerance ? 1 : 0;
+}
+
+function exactAmount(truth: number, prediction: number): number {
+  return Math.abs(prediction - truth) <= 1.0 ? 1 : 0;
+}
+
+export function scorePrediction(
+  variable: string,
+  country: CountryCode,
+  truth: number,
+  prediction: number | null | undefined,
+): number {
+  if (prediction === null || prediction === undefined || Number.isNaN(prediction)) {
+    return 0;
+  }
+  const metricType = metricTypeForVariable(variable, country);
+  if (metricType === "binary") {
+    return Math.round(prediction) === Math.round(truth) ? 1 : 0;
+  }
+  const exact = exactAmount(truth, prediction);
+  const w1 = within(truth, prediction, 0.01);
+  const w5 = within(truth, prediction, 0.05);
+  const w10 = within(truth, prediction, 0.1);
+  return (exact + w1 + w5 + w10) / 4;
+}
+
+// Touch the prefix/suffix tables so a future test can verify coverage.
+export const PERSON_OUTPUT_PREFIX_LIST: readonly string[] =
+  PERSON_OUTPUT_PREFIXES;
+export const PERSON_OUTPUT_SUFFIX_LIST: readonly string[] =
+  PERSON_OUTPUT_SUFFIXES;

--- a/app/src/lib/sensitivity.ts
+++ b/app/src/lib/sensitivity.ts
@@ -1,0 +1,211 @@
+import type {
+  BenchData,
+  CountryCode,
+  DashboardBundle,
+  ViewKey,
+} from "../types";
+import {
+  metricTypeForVariable,
+  outputGroupForVariable,
+  scorePrediction,
+  type ScoreRow,
+} from "./scoring";
+
+export type SensitivityViewId =
+  | "main"
+  | "amount_only"
+  | "binary_only"
+  | "positive_only"
+  | "zero_only";
+
+export type SensitivityView = {
+  id: SensitivityViewId;
+  label: string;
+  description: string;
+};
+
+export const SENSITIVITY_VIEWS: SensitivityView[] = [
+  {
+    id: "main",
+    label: "Main",
+    description: "Equal-weight average across output groups; baseline ranking.",
+  },
+  {
+    id: "amount_only",
+    label: "Amount only",
+    description: "Drops binary coverage flags; ranks on amount outputs only.",
+  },
+  {
+    id: "binary_only",
+    label: "Binary only",
+    description: "Restricts to binary coverage outputs.",
+  },
+  {
+    id: "positive_only",
+    label: "Positive cases",
+    description: "Restricts to rows where the reference value is non-zero.",
+  },
+  {
+    id: "zero_only",
+    label: "Zero cases",
+    description: "Restricts to rows where the reference value is zero.",
+  },
+];
+
+export type ScenarioRow = {
+  country: CountryCode;
+  scenarioId: string;
+  outputGroup: string;
+  model: string;
+  score: number;
+};
+
+function buildRows(country: CountryCode, payload: BenchData): ScoreRow[] {
+  const rows: ScoreRow[] = [];
+  for (const [scenarioId, variableMap] of Object.entries(
+    payload.scenarioPredictions,
+  )) {
+    for (const [variable, modelMap] of Object.entries(variableMap)) {
+      const outputGroup = outputGroupForVariable(variable);
+      const metricType = metricTypeForVariable(variable, country);
+      for (const [model, record] of Object.entries(modelMap)) {
+        rows.push({
+          country,
+          scenarioId,
+          variable,
+          outputGroup,
+          model,
+          truth: record.groundTruth,
+          prediction: record.prediction,
+          metricType,
+          score: scorePrediction(
+            variable,
+            country,
+            record.groundTruth,
+            record.prediction,
+          ),
+        });
+      }
+    }
+  }
+  return rows;
+}
+
+export function buildAllRows(dashboard: DashboardBundle): ScoreRow[] {
+  const rows: ScoreRow[] = [];
+  for (const country of ["us", "uk"] as CountryCode[]) {
+    const payload = dashboard.countries[country];
+    if (!payload) continue;
+    rows.push(...buildRows(country, payload));
+  }
+  return rows;
+}
+
+function filterRows(rows: ScoreRow[], view: SensitivityViewId): ScoreRow[] {
+  switch (view) {
+    case "main":
+      return rows;
+    case "amount_only":
+      return rows.filter((row) => row.metricType === "amount");
+    case "binary_only":
+      return rows.filter((row) => row.metricType === "binary");
+    case "positive_only":
+      return rows.filter((row) => row.truth !== 0);
+    case "zero_only":
+      return rows.filter((row) => row.truth === 0);
+    default:
+      return rows;
+  }
+}
+
+function aggregateGroupMean<T>(
+  rows: T[],
+  key: (row: T) => string,
+  value: (row: T) => number,
+): Record<string, number> {
+  const sums = new Map<string, { sum: number; count: number }>();
+  for (const row of rows) {
+    const k = key(row);
+    const v = value(row);
+    if (!Number.isFinite(v)) continue;
+    const cur = sums.get(k) ?? { sum: 0, count: 0 };
+    cur.sum += v;
+    cur.count += 1;
+    sums.set(k, cur);
+  }
+  const out: Record<string, number> = {};
+  for (const [k, { sum, count }] of sums) {
+    if (count > 0) out[k] = sum / count;
+  }
+  return out;
+}
+
+export type ModelScore = {
+  model: string;
+  score: number;
+};
+
+function scoresPerCountryModel(rows: ScoreRow[]): Map<
+  string,
+  Map<string, number>
+> {
+  // First reduce to (country, model, output_group) means.
+  const groupKey = (row: ScoreRow) =>
+    `${row.country}|${row.model}|${row.outputGroup}`;
+  const outputMeans = aggregateGroupMean(rows, groupKey, (row) => row.score * 100);
+  // Then average the output groups by (country, model).
+  const buckets = new Map<string, { sum: number; count: number }>();
+  for (const [k, mean] of Object.entries(outputMeans)) {
+    const [country, model] = k.split("|");
+    const bk = `${country}|${model}`;
+    const cur = buckets.get(bk) ?? { sum: 0, count: 0 };
+    cur.sum += mean;
+    cur.count += 1;
+    buckets.set(bk, cur);
+  }
+  // Reshape into Map<country, Map<model, score>>.
+  const out = new Map<string, Map<string, number>>();
+  for (const [bk, { sum, count }] of buckets) {
+    if (count === 0) continue;
+    const [country, model] = bk.split("|");
+    if (!out.has(country)) out.set(country, new Map());
+    out.get(country)!.set(model, sum / count);
+  }
+  return out;
+}
+
+export function modelScoresForView(
+  rows: ScoreRow[],
+  view: SensitivityViewId,
+  selectedView: ViewKey,
+): ModelScore[] {
+  const filtered = filterRows(rows, view);
+  const perCountry = scoresPerCountryModel(filtered);
+  if (selectedView === "global") {
+    const allModels = new Set<string>();
+    for (const map of perCountry.values()) {
+      for (const m of map.keys()) allModels.add(m);
+    }
+    const out: ModelScore[] = [];
+    for (const model of allModels) {
+      const present: number[] = [];
+      for (const map of perCountry.values()) {
+        const s = map.get(model);
+        if (s !== undefined && Number.isFinite(s)) present.push(s);
+      }
+      // Global score requires presence in both countries.
+      if (present.length === perCountry.size && perCountry.size > 0) {
+        out.push({
+          model,
+          score: present.reduce((a, b) => a + b, 0) / present.length,
+        });
+      }
+    }
+    return out.sort((a, b) => b.score - a.score);
+  }
+  const map = perCountry.get(selectedView);
+  if (!map) return [];
+  return [...map.entries()]
+    .map(([model, score]) => ({ model, score }))
+    .sort((a, b) => b.score - a.score);
+}

--- a/app/src/lib/sensitivity.ts
+++ b/app/src/lib/sensitivity.ts
@@ -4,6 +4,8 @@ import type {
   DashboardBundle,
   ViewKey,
 } from "../types";
+
+const GLOBAL_REQUIRED_COUNTRIES: readonly CountryCode[] = ["us", "uk"];
 import {
   metricTypeForVariable,
   outputGroupForVariable,
@@ -174,6 +176,17 @@ function scoresPerCountryModel(rows: ScoreRow[]): Map<
   return out;
 }
 
+/** Returns true if the active sensitivity slice has rows for every required country. */
+export function viewSupportsGlobal(
+  rows: ScoreRow[],
+  view: SensitivityViewId,
+): boolean {
+  const filtered = filterRows(rows, view);
+  const present = new Set<CountryCode>();
+  for (const row of filtered) present.add(row.country);
+  return GLOBAL_REQUIRED_COUNTRIES.every((c) => present.has(c));
+}
+
 export function modelScoresForView(
   rows: ScoreRow[],
   view: SensitivityViewId,
@@ -182,19 +195,27 @@ export function modelScoresForView(
   const filtered = filterRows(rows, view);
   const perCountry = scoresPerCountryModel(filtered);
   if (selectedView === "global") {
+    // Global score requires every required country to have rows under the
+    // active sensitivity slice. If any required country is missing (e.g.
+    // "Binary only" with no UK binary outputs), surface no rows so the
+    // leaderboard component can suppress or relabel the global view.
+    const haveAllRequired = GLOBAL_REQUIRED_COUNTRIES.every((c) =>
+      perCountry.has(c),
+    );
+    if (!haveAllRequired) return [];
+
     const allModels = new Set<string>();
-    for (const map of perCountry.values()) {
-      for (const m of map.keys()) allModels.add(m);
+    for (const c of GLOBAL_REQUIRED_COUNTRIES) {
+      for (const m of perCountry.get(c)?.keys() ?? []) allModels.add(m);
     }
     const out: ModelScore[] = [];
     for (const model of allModels) {
       const present: number[] = [];
-      for (const map of perCountry.values()) {
-        const s = map.get(model);
+      for (const c of GLOBAL_REQUIRED_COUNTRIES) {
+        const s = perCountry.get(c)?.get(model);
         if (s !== undefined && Number.isFinite(s)) present.push(s);
       }
-      // Global score requires presence in both countries.
-      if (present.length === perCountry.size && perCountry.size > 0) {
+      if (present.length === GLOBAL_REQUIRED_COUNTRIES.length) {
         out.push({
           model,
           score: present.reduce((a, b) => a + b, 0) / present.length,


### PR DESCRIPTION
## Summary

Implements the tier-1 leaderboard improvements from `docs/site_improvements_scope.md`, plus a shared sticky header that the `/paper` page now reuses (matching the home page chrome, without the Global/US/UK view selector). Round-2 review feedback is incorporated: the bootstrap estimator now matches the canonical row-equal scoring rule, and the global view auto-falls-back to Main when an active sensitivity slice has no rows in one country.

### Header
- Extract `SiteHeader` from `Hero`. The new component owns the sticky brand + nav + view-selector + action-link layout and supports an `alwaysExpanded` mode for pages that don't drive their own collapse.
- `Hero` refactored to wrap `SiteHeader` and pass the country-aware subtitle, stat strip, and snapshot pill as `expandedContent`. **Drops** the `Top score` stat and the `Leading: <model>` sidebar — the leaderboard itself is the canonical source for both.
- `/paper` uses `SiteHeader` with `alwaysExpanded`, no view selector, and a `Benchmark` action link. The page body keeps its eyebrow/buttons/iframe; the inline H1 is gone since the header carries the brand.
- Picked up the upstream parallel design tweak: dropped the inline "by [PE logo]" tagline next to the title and added a persistent "by PolicyEngine" pill at the right edge of the header.
- Collapsed nav items and action link are no longer keyboard-focusable while hidden (`tabIndex={-1}`, `aria-hidden`); the scroll listener short-circuits on `alwaysExpanded`.

### Open-set banner and snapshot pill
- `role="note"` warning-tinted banner above the leaderboard.
- Snapshot date pill (`Snapshot 2026-05-01`) on the home stat row and next to the `Manuscript` eyebrow on `/paper`.

### Sensitivity-view selector
- Segmented control: `Main` / `Amount only` / `Binary only` / `Positive cases` / `Zero cases`. Selecting a view rescores models client-side from `scenarioPredictions` and reorders the table; the description for the active view appears inline. The control is `role="group"` with `aria-labelledby`; each button has `aria-pressed`.
- **Auto-fallback for global:** when a slice has no rows in one country (e.g. Binary-only on Global, since UK has zero binary outputs), `viewSupportsGlobal` returns false, the leaderboard falls back to the Main view with a `role="note"` notice, and the offending button becomes `aria-disabled` with the click handler short-circuited so it cannot simultaneously be pressed and disabled.
- New utilities under `app/src/lib/`:
  - **`scoring.ts`** ports `score_single_prediction` (mean of exact / within-1% / within-5% / within-10% for amount outputs; classification accuracy for binary; output-group resolution for person-expanded variables). Verified against canonical `analysis.py` for both countries' top models.
  - **`sensitivity.ts`** builds the per-row score table from a `DashboardBundle` and aggregates output-group means → country → global, preserving country-equal weighting. Exposes `viewSupportsGlobal` for global-validity checks.

### Bootstrap rank intervals
- **`bootstrap.ts`** implements household-resampling with a deterministic `mulberry32` RNG (seed `42`, `DEFAULT_DRAWS = 400`). Inside each draw it adds bucket `sum` and `count` directly across sampled scenarios so each row contributes equally to the output-group mean — matching the headline `modelScoresForView` estimator instead of collapsing each scenario to a per-scenario mean first.
- `ModelLeaderboard` renders `Rank N(-M) · 95% L-U` next to each model's point estimate. Sample current Global view: Rank 1 has 95% CI ~74.7–79.6; Rank 2-3 cluster ~73.5–78.7. Tooltip names the bootstrap parameters.
- Snapshot top-3 scores against current `app/src/data.json`: US gpt-5.5 90.03 / grok-4.20 89.29 / gemini-3.1-pro-preview 88.21; UK gpt-5.5 77.18 / gemini-3.1-pro-preview 76.18 / grok-4.20 75.07; Global gpt-5.5 83.60 / gemini-3.1-pro-preview 82.20 / grok-4.20 82.18.

### Repo
- `.gitignore` keeps the Python `lib/` blanket ignore and adds an explicit `!app/src/lib/` + `!app/src/lib/**` allowlist so `app/src/lib/` is tracked while nested `lib/` directories elsewhere stay ignored.

## Verification
- `bun run lint` — clean
- `bun run build` — clean (Next.js 16 production build)
- `bun run start` — SSR HTML on `/` contains the open-set banner with `role="note"`, the snapshot pill, the sensitivity selector with `aria-pressed` × 5 and `role="group"`, the country view selector with `aria-pressed` × 3 and `role="group"`, per-model bootstrap intervals, and the "by PolicyEngine" pill. `/paper` renders the same chrome without the view selector.
- Scoring math reconciled against `policybench/analysis.py` for the snapshot's top-5 models per country.

## Test plan
- [ ] CI passes
- [ ] Visit `/` — confirm header drops "Top score" / "Leading" and the snapshot pill is visible
- [ ] Switch sensitivity view to `Positive cases` → leaderboard reorders and intervals refresh
- [ ] Switch to `Binary only` while on `Global` → leaderboard falls back to Main with a notice; the Binary-only button is aria-disabled
- [ ] Visit `/paper` → same sticky header style without a view selector
- [ ] Mobile width → bootstrap interval line wraps under each model row

🤖 Generated with [Claude Code](https://claude.com/claude-code)
