### PR TITLE
Wire repo-root vercel.json so policybench.org auto-deploys

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "framework": "nextjs",
+  "buildCommand": "cd app && bun install --frozen-lockfile && bun run build",
+  "installCommand": "echo 'deferred to buildCommand'",
+  "outputDirectory": "app/.next"
+}


### PR DESCRIPTION
## Why

Domain `policybench.org` is now bound to the `policybench-site` Vercel project (the legacy `app` and misconfigured `policybench` projects are gone). That project's `rootDirectory` is unset, so git auto-deploys try to build from repo root and find no Next.js app.

This adds a repo-root `vercel.json` that drives the build into `app/`:
- `framework: nextjs`
- `buildCommand: cd app && bun install --frozen-lockfile && bun run build`
- `outputDirectory: app/.next`

Result: pushing to `main` triggers a Vercel build that produces the same output as running `bun run build` inside `app/` locally, and the production deploy auto-promotes to `policybench.org`.

## Verification

- Vercel preview build for this PR will validate the config end-to-end.
- After merge, the next push should land on `policybench.org` automatically with no manual `vercel --prod` step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
