### PR TITLE
Add household-weighted view; hide bootstrap intervals behind a toggle

### DIFF
--- a/app/src/components/ModelLeaderboard.tsx
+++ b/app/src/components/ModelLeaderboard.tsx
@@ -16,6 +16,7 @@ import ProviderMark from "./ProviderMark";
 import {
   SENSITIVITY_VIEWS,
   buildAllRows,
+  householdImpactScores,
   modelScoresForView,
   viewSupportsSelected,
   type SensitivityViewId,
@@ -119,6 +120,7 @@ export default function ModelLeaderboard({
   const isGlobal = selectedView === "global";
   const [sensitivityView, setSensitivityView] =
     useState<SensitivityViewId>("main");
+  const [showIntervals, setShowIntervals] = useState(false);
 
   const allRows = useMemo(() => buildAllRows(dashboard), [dashboard]);
 
@@ -138,8 +140,11 @@ export default function ModelLeaderboard({
     : sensitivityView;
 
   const sensitivityScores = useMemo(() => {
+    if (effectiveView === "household_weighted") {
+      return householdImpactScores(dashboard, selectedView);
+    }
     return modelScoresForView(allRows, effectiveView, selectedView);
-  }, [allRows, effectiveView, selectedView]);
+  }, [allRows, dashboard, effectiveView, selectedView]);
 
   const sensitivityScoreByModel = useMemo(() => {
     const out = new Map<string, number>();
@@ -160,14 +165,20 @@ export default function ModelLeaderboard({
       .sort((a, b) => b.score - a.score);
   }, [data, effectiveView, sensitivityScoreByModel]);
 
+  // Bootstrap intervals are off by default — they roughly triple the
+  // first-paint cost and are noise to most readers. Compute on-demand when
+  // the user opens the toggle. Households-weighted view doesn't have a
+  // bootstrap path yet; fall back to no intervals there.
   const intervals = useMemo(() => {
+    if (!showIntervals) return new Map();
+    if (effectiveView === "household_weighted") return new Map();
     return bootstrapIntervals(
       allRows,
       selectedView,
       viewToFilter(effectiveView),
       { draws: DEFAULT_DRAWS, seed: 42 },
     );
-  }, [allRows, selectedView, effectiveView]);
+  }, [allRows, selectedView, effectiveView, showIntervals]);
 
   const pendingModels = useMemo<PendingModel[]>(() => {
     const present = new Set(noTools.map((model) => model.model));
@@ -281,6 +292,16 @@ export default function ModelLeaderboard({
         <span className="text-[11px] text-text-muted">
           {activeView.description}
         </span>
+        <label className="ml-auto inline-flex items-center gap-1.5 text-[11px] text-text-secondary">
+          <input
+            type="checkbox"
+            checked={showIntervals}
+            onChange={(event) => setShowIntervals(event.target.checked)}
+            className="h-3 w-3 rounded border-border accent-primary"
+            aria-label="Show 95% bootstrap intervals"
+          />
+          <span>Show 95% intervals</span>
+        </label>
       </div>
       {sensitivityUnsupportedForView && (
         <p

--- a/app/src/lib/sensitivity.ts
+++ b/app/src/lib/sensitivity.ts
@@ -15,6 +15,7 @@ import {
 
 export type SensitivityViewId =
   | "main"
+  | "household_weighted"
   | "amount_only"
   | "binary_only"
   | "positive_only"
@@ -31,6 +32,12 @@ export const SENSITIVITY_VIEWS: SensitivityView[] = [
     id: "main",
     label: "Main",
     description: "Equal-weight average across output groups; baseline ranking.",
+  },
+  {
+    id: "household_weighted",
+    label: "Household-weighted",
+    description:
+      "Each household contributes equally; within a household, outputs are weighted by absolute reference dollar share (with a 0.3 floor).",
   },
   {
     id: "amount_only",
@@ -193,12 +200,37 @@ export function viewSupportsSelected(
   view: SensitivityViewId,
   selectedView: ViewKey,
 ): boolean {
+  if (view === "household_weighted") return true;
   if (selectedView === "global") return viewSupportsGlobal(rows, view);
   const filtered = filterRows(rows, view);
   for (const row of filtered) {
     if (row.country === selectedView) return true;
   }
   return false;
+}
+
+/** Read pre-computed household-equal impact scores from the dashboard payload. */
+export function householdImpactScores(
+  dashboard: DashboardBundle,
+  selectedView: ViewKey,
+): ModelScore[] {
+  const scores: ModelScore[] = [];
+  if (selectedView === "global") {
+    for (const stat of dashboard.global?.modelStats ?? []) {
+      if (stat.condition !== "no_tools") continue;
+      if (typeof stat.impactScore !== "number") continue;
+      scores.push({ model: stat.model, score: stat.impactScore });
+    }
+  } else {
+    const country = dashboard.countries[selectedView];
+    if (!country) return [];
+    for (const stat of country.modelStats) {
+      if (stat.condition !== "no_tools") continue;
+      if (typeof stat.impactScore !== "number") continue;
+      scores.push({ model: stat.model, score: stat.impactScore });
+    }
+  }
+  return scores.sort((a, b) => b.score - a.score);
 }
 
 export function modelScoresForView(

--- a/app/src/types.ts
+++ b/app/src/types.ts
@@ -206,6 +206,8 @@ export type ModelStat = {
   maeRunMean?: number;
   maeRunStd?: number;
   countryScores?: Partial<Record<CountryCode, number>>;
+  impactScore?: number;
+  impactCountryScores?: Partial<Record<CountryCode, number>>;
 };
 
 export type ProgramStat = {

--- a/paper/snapshot/20260501/manifest.json
+++ b/paper/snapshot/20260501/manifest.json
@@ -6,7 +6,7 @@
   },
   "dashboard_export": {
     "path": "app/src/data.json",
-    "sha256": "d3ee592e809d341cc734eba6c4a5ce4a762660d6082e1eaf5a0ce2a6ad8e9d20",
+    "sha256": "916923fcf29cdc26877366ac618c3c2bcb959bbfaf940fff7ca4826f6e46fe45",
     "description": "Committed dashboard export containing parsed model predictions, explanations, model summaries, program summaries, prompts, and PolicyEngine runtime bundle metadata."
   },
   "source_run_labels": {

--- a/policybench/analysis.py
+++ b/policybench/analysis.py
@@ -1180,6 +1180,16 @@ def build_dashboard_payload(
                 item["prompt"] = first_prompt
         scenario_payload[row["scenario_id"]] = item
 
+    impact_summary = analysis.get("impact_summary")
+    impact_by_model: dict[str, float] = {}
+    if isinstance(impact_summary, pd.DataFrame) and not impact_summary.empty:
+        for _, impact_row in impact_summary.iterrows():
+            model_name = impact_row.get("model")
+            score = impact_row.get("mean_impact_score")
+            if model_name is None or pd.isna(score):
+                continue
+            impact_by_model[str(model_name)] = float(score) * 100
+
     model_stats = []
     for _, row in (
         analysis["model_summary"].sort_values("mean_score", ascending=False).iterrows()
@@ -1285,6 +1295,9 @@ def build_dashboard_payload(
         }
         if not pd.isna(row["mean_accuracy"]):
             item["accuracy"] = float(row["mean_accuracy"] * 100)
+        impact_score = impact_by_model.get(str(row["model"]))
+        if impact_score is not None:
+            item["impactScore"] = impact_score
         model_stats.append({k: v for k, v in item.items() if v is not None})
 
     program_rows = []
@@ -1425,6 +1438,14 @@ def build_global_dashboard_payload(country_payloads: dict[str, dict]) -> dict:
         accuracy = _mean([row.get("accuracy") for row in rows.values()])
         if accuracy is not None:
             item["accuracy"] = accuracy
+        impact_values = [row.get("impactScore") for row in rows.values()]
+        if all(value is not None for value in impact_values) and impact_values:
+            item["impactScore"] = _mean(impact_values)
+            item["impactCountryScores"] = {
+                country: float(row["impactScore"])
+                for country, row in rows.items()
+                if row.get("impactScore") is not None
+            }
         model_stats.append(item)
 
     model_stats.sort(key=lambda row: row["score"], reverse=True)


### PR DESCRIPTION
## Summary

Two leaderboard tweaks following live-site review:

### 1. Household-weighted view
- New sensitivity option that ranks models by the canonical `household_equal_impact_scores` statistic (each household contributes equally; outputs within a household are weighted by absolute reference dollar share with a 0.3 floor). This is the same statistic the paper's `@tbl-impact-floor` is built on.
- `policybench/analysis.py:build_dashboard_payload` reads `analysis['impact_summary']` and writes `impactScore` (per country) and `impactCountryScores` (in the global view) into `modelStats`. `app/src/data.json` regenerated from the committed `paper/snapshot/20260501/{us,uk}_impact_summary_by_model.csv`. Manifest dashboard sha256 refreshed.
- Site reads `modelStats[].impactScore` directly when the household-weighted view is active — no client-side recomputation needed.

### 2. Bootstrap intervals hidden by default
- The `Rank N · 95% L–U` line was a lot of noise for casual visitors. The leaderboard now hides intervals by default and exposes a `Show 95% intervals` checkbox in the controls row.
- When the toggle is off, the bootstrap computation is **skipped entirely**, so first paint no longer pays the 400-draw cost on mobile.
- Intervals stay hidden under the Household-weighted view (no bootstrap path for that estimator yet).

## Verification
- `uv run pytest -q` clean (190 passed)
- `bunx eslint . --max-warnings=0` clean
- `bun run build` clean
- SSR HTML on `/` contains all six sensitivity views, the `Show 95% intervals` toggle, and no `Rank`/`95%` interval strings; `Binary only` is disabled on Global as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
