### PR TITLE
Remove unused rate output_type code path

### DIFF
--- a/policybench/analysis.py
+++ b/policybench/analysis.py
@@ -9,7 +9,6 @@ import pandas as pd
 from policybench.config import (
     BINARY_PROGRAMS,
     HOUSEHOLD_IMPACT_SCORE_FLOOR,
-    RATE_PROGRAMS,
 )
 from policybench.policyengine_runtime import policyengine_bundles_for_countries
 from policybench.prompts import make_no_tools_batch_prompt
@@ -130,19 +129,11 @@ def score_single_prediction(
     if metric_type == "binary" or variable in BINARY_PROGRAMS:
         return accuracy(y_true_arr, y_pred_arr)
 
-    if metric_type == "rate" or variable in RATE_PROGRAMS:
-        exact = exact_amount_match(
-            y_true_arr,
-            y_pred_arr,
-            absolute_tolerance=1e-4,
-        )
-    else:
-        exact = exact_amount_match(
-            y_true_arr,
-            y_pred_arr,
-            absolute_tolerance=1.0,
-        )
-
+    exact = exact_amount_match(
+        y_true_arr,
+        y_pred_arr,
+        absolute_tolerance=1.0,
+    )
     within_1pct = within_tolerance(y_true_arr, y_pred_arr, tolerance=0.01)
     within_5pct = within_tolerance(y_true_arr, y_pred_arr, tolerance=0.05)
     within_10pct = within_tolerance(y_true_arr, y_pred_arr, tolerance=0.10)
@@ -514,23 +505,6 @@ def compute_metrics(
             row["within_5pct"] = accuracy_score
             row["within_10pct"] = accuracy_score
             row["score"] = accuracy_score
-        elif metric_type == "rate" or variable in RATE_PROGRAMS:
-            exact = (
-                exact_amount_match(y_true, y_pred, absolute_tolerance=1e-4) * coverage
-            )
-            within_1pct = within_tolerance(y_true, y_pred, tolerance=0.01) * coverage
-            within_5pct = within_tolerance(y_true, y_pred, tolerance=0.05) * coverage
-            within_10pct = within_tolerance(y_true, y_pred, tolerance=0.10) * coverage
-            row["mae"] = mean_absolute_error(y_true, y_pred)
-            row["mape"] = float("nan")
-            row["accuracy"] = float("nan")
-            row["exact"] = exact
-            row["within_1pct"] = within_1pct
-            row["within_5pct"] = within_5pct
-            row["within_10pct"] = within_10pct
-            row["score"] = float(
-                np.mean([exact, within_1pct, within_5pct, within_10pct])
-            )
         else:
             exact = (
                 exact_amount_match(y_true, y_pred, absolute_tolerance=1.0) * coverage

--- a/policybench/config.py
+++ b/policybench/config.py
@@ -5,7 +5,6 @@ from policybench.spec import (
     available_spec_ids,
     binary_output_ids,
     get_output_ids,
-    rate_output_ids,
 )
 
 # Tax year for all evaluations
@@ -68,9 +67,6 @@ PROGRAMS = US_HEADLINE_PROGRAMS
 
 # Binary (eligibility) variables -- evaluated with accuracy, not MAE
 BINARY_PROGRAMS = binary_output_ids()
-
-# Rate variables -- evaluated with absolute error, not percentage
-RATE_PROGRAMS = rate_output_ids()
 
 # Proposed impact-score floor. Each household gets equal overall weight, while
 # programs within a household receive a blend of equal weighting and weighting

--- a/policybench/spec.py
+++ b/policybench/spec.py
@@ -116,10 +116,6 @@ class OutputSpec:
         return self.metric_type == "binary"
 
     @property
-    def is_rate(self) -> bool:
-        return self.metric_type == "rate"
-
-    @property
     def is_budget_component(self) -> bool:
         return self.metric_type == "amount" and self.net_income_sign != 0
 
@@ -440,11 +436,4 @@ def binary_output_ids() -> list[str]:
     return sorted(
         {output.id for output in iter_output_specs() if output.metric_type == "binary"}
         | set(PERSON_ELIGIBILITY_OUTPUTS)
-    )
-
-
-def rate_output_ids() -> list[str]:
-    """Return all rate output ids across specs."""
-    return sorted(
-        {output.id for output in iter_output_specs() if output.metric_type == "rate"}
     )


### PR DESCRIPTION
## Summary

The benchmark has only \`amount\` (18) and \`binary\` (8) metric types in \`benchmark_specs.json\` — zero \`rate\` outputs. The scaffolding for \`metric_type == "rate"\` is unreachable. Removed:

- \`spec.py\`: \`is_rate\` property and \`rate_output_ids()\` helper.
- \`config.py\`: \`RATE_PROGRAMS\` constant and the corresponding import.
- \`analysis.py\`: \`RATE_PROGRAMS\` import, the rate branch in \`score_single_prediction()\`, and the rate branch in the per-variable summary builder.

If rate outputs are reintroduced later, the branch can be reconstructed from git history.

## Test plan

- [x] \`pytest -m "not slow"\` — 229 passed, 10 deselected.
- [x] \`ruff check\` — passes.
- [x] \`ruff format --check\` — passes.