### PR TITLE
Fix header reveal flicker while scrolling

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -8,7 +8,8 @@
     "dev": "next dev --turbopack",
     "build": "next build",
     "start": "next start",
-    "lint": "eslint . --max-warnings=0"
+    "lint": "eslint . --max-warnings=0",
+    "test": "bun test tests"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4.2.4",

--- a/app/public/metric-options.html
+++ b/app/public/metric-options.html
@@ -525,7 +525,7 @@
             <section id="setup" class="step">
               <h2><span class="step-num">1</span>The setup</h2>
               <p class="sub">
-                Three households, five outputs (four dollar amounts plus one
+                Three households, four outputs (three dollar amounts plus one
                 eligibility flag), two models. Every step on this page uses
                 the same numbers.
               </p>
@@ -656,9 +656,9 @@
 
               <div class="card">
                 <p>
-                  Average the five row scores into a household score, then
+                  Average the four row scores into a household score, then
                   average the household scores into a model score. Each output
-                  gets a weight of 1/5 in every household.
+                  gets a weight of 1/4 in every household.
                 </p>
                 <div class="table-wrap" id="equal-table"></div>
                 <div class="verdict">
@@ -695,7 +695,7 @@
                 <p>
                   Now an output gets weight in proportion to its dollar size
                   for that household. A $5,000 income tax line carries more
-                  weight than a $500 ACA premium tax credit.
+                  weight than a $500 benefit line.
                 </p>
                 <div class="table-wrap" id="impact-weights-table"></div>
                 <div class="table-wrap" id="impact-table"></div>
@@ -877,9 +877,8 @@
                   The "share of net income that flowed through this program"
                   reading is intuitive. Medicaid eligibility carries a
                   meaningful weight because it shows up with sizeable paired
-                  values in two of the four households; ACA PTC carries
-                  smaller weight because only one household uses it. None
-                  of these numbers required a tunable parameter.
+                  values in two of the four households. None of these numbers
+                  required a tunable parameter.
                 </p>
               </div>
             </section>
@@ -1309,7 +1308,6 @@
         { id: "income_tax", label: "Income tax", kind: "amount" },
         { id: "payroll_tax", label: "Payroll tax", kind: "amount" },
         { id: "snap", label: "SNAP", kind: "amount" },
-        { id: "aca_ptc", label: "ACA PTC", kind: "amount" },
         {
           id: "medicaid_eligible",
           label: "Medicaid eligibility",
@@ -1329,7 +1327,6 @@
             income_tax: -4000,
             payroll_tax: -5000,
             snap: 0,
-            aca_ptc: 0,
             medicaid_eligible: false,
             medicaid_value: 0,
           },
@@ -1342,7 +1339,6 @@
             income_tax: -1000,
             payroll_tax: -1500,
             snap: 6000,
-            aca_ptc: 8000,
             medicaid_eligible: true,
             medicaid_value: 6000,
           },
@@ -1355,7 +1351,6 @@
             income_tax: -2000,
             payroll_tax: 0,
             snap: 2400,
-            aca_ptc: 0,
             medicaid_eligible: true,
             medicaid_value: 9000,
           },
@@ -1374,7 +1369,6 @@
             income_tax: 3000,
             payroll_tax: -1530,
             snap: 5000,
-            aca_ptc: 3000,
             medicaid_eligible: true,
             medicaid_value: 8000,
           },
@@ -1387,7 +1381,6 @@
             income_tax: -4500,
             payroll_tax: -4590,
             snap: 0,
-            aca_ptc: 0,
             medicaid_eligible: false,
             medicaid_value: 0,
           },
@@ -1400,7 +1393,6 @@
             income_tax: 0,
             payroll_tax: 0,
             snap: 2400,
-            aca_ptc: 0,
             medicaid_eligible: true,
             medicaid_value: 9000,
           },
@@ -1413,7 +1405,6 @@
             income_tax: -40000,
             payroll_tax: -9900,
             snap: 0,
-            aca_ptc: 0,
             medicaid_eligible: false,
             medicaid_value: 0,
           },
@@ -1425,18 +1416,18 @@
           id: "tax",
           label: "Tax-focused",
           predictions: {
-            H1: { income_tax: -4000, payroll_tax: -5000, snap: 0, aca_ptc: 0, medicaid_eligible: false },
-            H2: { income_tax: -1000, payroll_tax: -1500, snap: 0, aca_ptc: 0, medicaid_eligible: false },
-            H3: { income_tax: -2000, payroll_tax: 0, snap: 0, aca_ptc: 0, medicaid_eligible: false },
+            H1: { income_tax: -4000, payroll_tax: -5000, snap: 0, medicaid_eligible: false },
+            H2: { income_tax: -1000, payroll_tax: -1500, snap: 0, medicaid_eligible: false },
+            H3: { income_tax: -2000, payroll_tax: 0, snap: 0, medicaid_eligible: false },
           },
         },
         {
           id: "benefit",
           label: "Benefit-focused",
           predictions: {
-            H1: { income_tax: -2000, payroll_tax: -4000, snap: 0, aca_ptc: 0, medicaid_eligible: false },
-            H2: { income_tax: 0, payroll_tax: -1000, snap: 6000, aca_ptc: 8000, medicaid_eligible: true },
-            H3: { income_tax: -1000, payroll_tax: 0, snap: 2400, aca_ptc: 0, medicaid_eligible: true },
+            H1: { income_tax: -2000, payroll_tax: -4000, snap: 0, medicaid_eligible: false },
+            H2: { income_tax: 0, payroll_tax: -1000, snap: 6000, medicaid_eligible: true },
+            H3: { income_tax: -1000, payroll_tax: 0, snap: 2400, medicaid_eligible: true },
           },
         },
       ];

--- a/app/public/paper/web/index.html
+++ b/app/public/paper/web/index.html
@@ -362,7 +362,7 @@ Table&nbsp;1: Frozen manuscript snapshot.
 <tr class="odd">
 <th data-quarto-table-cell-role="th">30</th>
 <td>Output groups</td>
-<td>19 US and 7 UK</td>
+<td>18 US and 7 UK</td>
 </tr>
 <tr class="even">
 <th data-quarto-table-cell-role="th">31</th>
@@ -539,7 +539,7 @@ Table&nbsp;2: Model run configuration in the frozen manuscript snapshot.
 <h2 id="data-and-scenario-construction" class="anchored">Data and scenario construction</h2>
 <h3 id="united-states" class="anchored">United States</h3>
 <p>The US benchmark is built from Enhanced Current Population Survey (CPS)-derived households using PolicyEngine US. The sampled households are filtered to keep a single-tax-unit, single-family, single-Supplemental Poverty Measure (SPM)-unit structure with at least one adult and a supported filing status. The 2024 Enhanced CPS source contains 41,314 households; 30,173 (73.0%) pass the filter and form the eligible draw. The 27.0% excluded by the filter include multi-tax-unit households (e.g., adult roommates), multi-family households, multi-SPM-unit households, and households whose head reports a filing status outside the supported set. These excluded compositions are exactly the kind of cases where federal/state credit allocations and benefit-unit rules become hardest, so the eligible draw is a tractable subset rather than the full distribution of US households. Prompts include nonzero promptable raw inputs across relevant entities rather than a hand-curated summary, so the models see many of the same facts the simulator receives. Filing status is not stated in the prompt; the reference computation infers it from tax-unit role flags. Models therefore see the same household facts that drive the reference filing-status assignment, but they do not receive that assignment as a label.</p>
-<p>The current US release evaluates 19 output groups spanning federal income tax, refundable credits, payroll and self-employment tax, state and local income tax, Supplemental Nutrition Assistance Program (SNAP), Supplemental Security Income (SSI), Temporary Assistance for Needy Families (TANF), Affordable Care Act (ACA) premium tax credits, school-meal eligibility, and person-level coverage eligibility for the Special Supplemental Nutrition Program for Women, Infants, and Children (WIC), Medicaid, the Children’s Health Insurance Program (CHIP), Medicare, Head Start, and Early Head Start.</p>
+<p>The current US release evaluates 18 output groups spanning federal income tax, refundable credits, payroll and self-employment tax, state and local income tax, Supplemental Nutrition Assistance Program (SNAP), Supplemental Security Income (SSI), Temporary Assistance for Needy Families (TANF), school-meal eligibility, and person-level coverage eligibility for the Special Supplemental Nutrition Program for Women, Infants, and Children (WIC), Medicaid, the Children’s Health Insurance Program (CHIP), Medicare, Head Start, and Early Head Start.</p>
 <p>The output scope is intentionally narrower than the full PolicyEngine model. <a href="#tbl-scope-rationale" class="quarto-xref">Table&nbsp;3</a> summarizes the inclusion rule. The benchmark asks for WIC eligibility rather than a WIC dollar amount; WIC dollar values are used only as impact-weight proxies for coverage flags, not as requested model outputs.</p>
 <div class="cell" data-execution_count="4">
 <div id="tbl-scope-rationale" class="cell quarto-float quarto-figure quarto-figure-center anchored" data-execution_count="4">
@@ -583,18 +583,13 @@ Table&nbsp;3: Output-selection rationale.
 <td>Excluded</td>
 <td>Intermediate tax bases, payroll subcomponents, and outputs that mainly require unavailable history, restricted local market data, restricted program-administration data, or take-up assignment rather than rule calculation.</td>
 </tr>
-<tr class="odd">
-<th data-quarto-table-cell-role="th">2</th>
-<td>ACA Premium Tax Credit</td>
-<td>Retained as a deliberate health-support output; when local benchmark premiums are not listed, the model must estimate them from the household facts.</td>
-</tr>
 <tr class="even">
-<th data-quarto-table-cell-role="th">3</th>
+<th data-quarto-table-cell-role="th">2</th>
 <td>Binary coverage outputs</td>
 <td>Requested as 0/1 eligibility flags and scored as classification tasks; their dollar values are used only as impact-weight proxies, not as requested model outputs.</td>
 </tr>
 <tr class="odd">
-<th data-quarto-table-cell-role="th">4</th>
+<th data-quarto-table-cell-role="th">3</th>
 <td>WIC</td>
 <td>The benchmark asks for person-level WIC eligibility. It does not ask models to estimate a WIC dollar amount.</td>
 </tr>
@@ -1999,7 +1994,7 @@ Table&nbsp;18: Structured-output parser audit and repair sequence.
 <tr class="odd">
 <th data-quarto-table-cell-role="th">4</th>
 <td>Final parse coverage</td>
-<td>The repaired manuscript snapshot has zero missing parsed numeric values and zero missing explanations across all 34,656 model-output rows.</td>
+<td>The repaired manuscript snapshot has zero missing parsed numeric values and zero missing explanations across all 33,456 model-output rows.</td>
 </tr>
 <tr class="even">
 <th data-quarto-table-cell-role="th">5</th>

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -8,10 +8,11 @@ import Methodology from "./components/Methodology";
 import ModelLeaderboard from "./components/ModelLeaderboard";
 import ProgramHeatmap from "./components/ProgramHeatmap";
 import ScenarioExplorer from "./components/ScenarioExplorer";
+import { filterExcludedOutputs } from "./lib/dashboardFilter";
 import type { CountryCode, DashboardBundle, ViewKey } from "./types";
 import { VIEW_LABELS } from "./types";
 
-const dashboard = rawData as DashboardBundle;
+const dashboard = filterExcludedOutputs(rawData as DashboardBundle);
 
 export type { DashboardBundle } from "./types";
 

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import rawData from "./data.json";
 import Hero from "./components/Hero";
 import FailureModes from "./components/FailureModes";
@@ -9,6 +9,12 @@ import ModelLeaderboard from "./components/ModelLeaderboard";
 import ProgramHeatmap from "./components/ProgramHeatmap";
 import ScenarioExplorer from "./components/ScenarioExplorer";
 import { filterExcludedOutputs } from "./lib/dashboardFilter";
+import {
+  buildProgramOptions,
+  resolveActiveProgramIds,
+  selectOnlyProgram as selectOnlyProgramFilter,
+  toggleProgramSelection,
+} from "./lib/programFilters";
 import type { CountryCode, DashboardBundle, ViewKey } from "./types";
 import { VIEW_LABELS } from "./types";
 
@@ -65,6 +71,9 @@ export default function App() {
     : (availableViews[0] ?? "us");
   const [selectedView, setSelectedView] = useState<CountryCode>(initialView);
   const [hasUserPickedView, setHasUserPickedView] = useState(false);
+  const [selectedPrograms, setSelectedPrograms] = useState<Set<string>>(
+    () => new Set(),
+  );
 
   useEffect(() => {
     if (hasUserPickedView) return;
@@ -81,6 +90,40 @@ export default function App() {
 
   const data = dashboard.countries[selectedView]!;
   const navItems = COUNTRY_NAV_ITEMS;
+
+  const programOptions = useMemo(() => buildProgramOptions(data), [data]);
+
+  const programOptionIds = useMemo(
+    () => programOptions.map((option) => option.variable),
+    [programOptions],
+  );
+
+  const activeProgramIds = useMemo(() => {
+    return resolveActiveProgramIds(programOptionIds, selectedPrograms);
+  }, [programOptionIds, selectedPrograms]);
+
+  const activeProgramSummary =
+    activeProgramIds.size < programOptions.length
+      ? `${activeProgramIds.size} of ${programOptions.length} selected`
+      : `All ${programOptions.length} programs`;
+
+  const resetPrograms = useCallback(() => {
+    setSelectedPrograms(new Set());
+  }, []);
+
+  const toggleProgram = useCallback(
+    (variable: string) => {
+      setSelectedPrograms((previous) => {
+        return toggleProgramSelection(programOptionIds, previous, variable);
+      });
+    },
+    [programOptionIds],
+  );
+
+  const selectOnlyProgram = useCallback((variable: string) => {
+    setSelectedPrograms(selectOnlyProgramFilter(variable));
+  }, []);
+
   const handleSelectView = (view: ViewKey) => {
     if (view === "global") return;
     setSelectedView(view);
@@ -155,12 +198,26 @@ export default function App() {
             data={data}
             selectedView={selectedView}
             dashboard={dashboard}
+            programOptions={programOptions}
+            activeProgramIds={activeProgramIds}
+            activeProgramSummary={activeProgramSummary}
+            onResetPrograms={resetPrograms}
+            onToggleProgram={toggleProgram}
+            onSelectOnlyProgram={selectOnlyProgram}
           />
         </section>
 
         <div className="h-px bg-gradient-to-r from-transparent via-border/40 to-transparent" />
         <section id="programs" className="scroll-mt-20 pt-12 pb-16 sm:pt-16 sm:pb-20">
-          <ProgramHeatmap data={data} />
+          <ProgramHeatmap
+            data={data}
+            programOptions={programOptions}
+            activeProgramIds={activeProgramIds}
+            activeProgramSummary={activeProgramSummary}
+            onResetPrograms={resetPrograms}
+            onToggleProgram={toggleProgram}
+            onSelectOnlyProgram={selectOnlyProgram}
+          />
         </section>
 
         <div className="h-px bg-gradient-to-r from-transparent via-border/40 to-transparent" />
@@ -168,6 +225,12 @@ export default function App() {
           <ScenarioExplorer
             key={data.country}
             data={data}
+            programOptions={programOptions}
+            activeProgramIds={activeProgramIds}
+            activeProgramSummary={activeProgramSummary}
+            onResetPrograms={resetPrograms}
+            onToggleProgram={toggleProgram}
+            onSelectOnlyProgram={selectOnlyProgram}
           />
         </section>
 

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -18,9 +18,9 @@ export type { DashboardBundle } from "./types";
 
 const COUNTRY_NAV_ITEMS = [
   { id: "models", label: "Models" },
+  { id: "programs", label: "Programs" },
   { id: "scenarios", label: "Scenarios" },
   { id: "failure-modes", label: "Failure" },
-  { id: "programs", label: "Programs" },
   { id: "methodology", label: "Method" },
 ] as const;
 
@@ -159,6 +159,11 @@ export default function App() {
         </section>
 
         <div className="h-px bg-gradient-to-r from-transparent via-border/40 to-transparent" />
+        <section id="programs" className="scroll-mt-20 pt-12 pb-16 sm:pt-16 sm:pb-20">
+          <ProgramHeatmap data={data} />
+        </section>
+
+        <div className="h-px bg-gradient-to-r from-transparent via-border/40 to-transparent" />
         <section id="scenarios" className="scroll-mt-20 pt-12 pb-16 sm:pt-16 sm:pb-20">
           <ScenarioExplorer
             key={data.country}
@@ -172,11 +177,6 @@ export default function App() {
           className="scroll-mt-20 pt-12 pb-16 sm:pt-16 sm:pb-20"
         >
           <FailureModes data={data} />
-        </section>
-
-        <div className="h-px bg-gradient-to-r from-transparent via-border/40 to-transparent" />
-        <section id="programs" className="scroll-mt-20 pt-12 pb-16 sm:pt-16 sm:pb-20">
-          <ProgramHeatmap data={data} />
         </section>
 
         <div className="h-px bg-gradient-to-r from-transparent via-border/40 to-transparent" />

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -8,7 +8,7 @@ import Methodology from "./components/Methodology";
 import ModelLeaderboard from "./components/ModelLeaderboard";
 import ProgramHeatmap from "./components/ProgramHeatmap";
 import ScenarioExplorer from "./components/ScenarioExplorer";
-import type { BenchData, CountryCode, DashboardBundle, ViewKey } from "./types";
+import type { CountryCode, DashboardBundle, ViewKey } from "./types";
 import { VIEW_LABELS } from "./types";
 
 const dashboard = rawData as DashboardBundle;
@@ -23,27 +23,16 @@ const COUNTRY_NAV_ITEMS = [
   { id: "methodology", label: "Method" },
 ] as const;
 
-const GLOBAL_NAV_ITEMS = [
-  { id: "models", label: "Models" },
-  { id: "methodology", label: "Method" },
-] as const;
-
 const COUNTRY_ORDER: CountryCode[] = ["us", "uk"];
 
-function getAvailableViews(dashboard: DashboardBundle): ViewKey[] {
-  const countryViews = COUNTRY_ORDER.filter((country) => dashboard.countries[country]);
-  if (dashboard.global?.modelStats.length && countryViews.length > 1) {
-    return ["global", ...countryViews];
-  }
-  return countryViews;
+function getAvailableViews(dashboard: DashboardBundle): CountryCode[] {
+  return COUNTRY_ORDER.filter((country) => dashboard.countries[country]);
 }
 
-/** Map IANA timezone or BCP-47 language to a benchmark country, when we can tell. */
-function detectVisitorCountry(
-  availableViews: readonly ViewKey[],
-): CountryCode | null {
+/** Default UK visitors to the UK benchmark; everyone else starts on the US benchmark. */
+function detectVisitorCountry(availableViews: readonly CountryCode[]): CountryCode {
   if (typeof window === "undefined" || typeof navigator === "undefined") {
-    return null;
+    return availableViews.includes("us") ? "us" : (availableViews[0] ?? "us");
   }
   let timezone = "";
   try {
@@ -53,11 +42,6 @@ function detectVisitorCountry(
   }
   const langs = (navigator.languages ?? [navigator.language ?? ""])
     .map((value) => value.toLowerCase());
-  const matchesUS =
-    timezone.startsWith("America/") ||
-    timezone === "Pacific/Honolulu" ||
-    timezone === "Pacific/Pago_Pago" ||
-    langs.some((lang) => lang === "en-us" || lang.endsWith("-us"));
   const matchesUK =
     timezone === "Europe/London" ||
     timezone === "Europe/Belfast" ||
@@ -67,26 +51,24 @@ function detectVisitorCountry(
     langs.some((lang) =>
       ["en-gb", "cy-gb", "gd-gb", "en-uk"].includes(lang),
     );
-  if (matchesUS && availableViews.includes("us")) return "us";
   if (matchesUK && availableViews.includes("uk")) return "uk";
-  return null;
+  return availableViews.includes("us") ? "us" : (availableViews[0] ?? "us");
 }
 
 export default function App() {
   const availableViews = useMemo(() => getAvailableViews(dashboard), []);
-  // Default to the global leaderboard. After mount we try to switch to the
-  // visitor's country (US or UK) when we can detect it from timezone or
-  // navigator.language; if neither matches we stay on Global.
-  const initialView: ViewKey = availableViews.includes("global")
-    ? "global"
-    : (availableViews[0] ?? "global");
-  const [selectedView, setSelectedView] = useState<ViewKey>(initialView);
+  // Default to the US benchmark, then switch UK visitors after mount when
+  // timezone or browser language gives us a clear signal.
+  const initialView: CountryCode = availableViews.includes("us")
+    ? "us"
+    : (availableViews[0] ?? "us");
+  const [selectedView, setSelectedView] = useState<CountryCode>(initialView);
   const [hasUserPickedView, setHasUserPickedView] = useState(false);
 
   useEffect(() => {
     if (hasUserPickedView) return;
     const detected = detectVisitorCountry(availableViews);
-    if (detected && detected !== selectedView) {
+    if (detected !== selectedView) {
       setSelectedView(detected);
     }
     // We only want this auto-pick to run once per session; further changes
@@ -96,12 +78,10 @@ export default function App() {
   const [activeNav, setActiveNav] = useState<string>("models");
   const observerRef = useRef<IntersectionObserver | null>(null);
 
-  const isGlobal = selectedView === "global";
-  const data = isGlobal
-    ? dashboard.global!
-    : dashboard.countries[selectedView as CountryCode]!;
-  const navItems = isGlobal ? GLOBAL_NAV_ITEMS : COUNTRY_NAV_ITEMS;
+  const data = dashboard.countries[selectedView]!;
+  const navItems = COUNTRY_NAV_ITEMS;
   const handleSelectView = (view: ViewKey) => {
+    if (view === "global") return;
     setSelectedView(view);
     setHasUserPickedView(true);
     setActiveNav("models");
@@ -139,19 +119,10 @@ export default function App() {
   );
 
   const footerCopy = useMemo(() => {
-    if (isGlobal) {
-      const totalHouseholds = Object.values(dashboard.countries).reduce(
-        (sum, country) => sum + Object.keys(country?.scenarios ?? {}).length,
-        0
-      );
-      const countryCount = Object.keys(dashboard.countries).length;
-      return `PolicyBench — global leaderboard across ${dashboard.global?.sharedModelCount ?? 0} shared frontier models, ${countryCount} country benchmarks, and ${totalHouseholds.toLocaleString()} households.`;
-    }
-
-    const countryData = data as BenchData;
+    const countryData = data;
     const scoredRows = noToolsModels.reduce((sum, model) => sum + model.n, 0);
     return `PolicyBench — ${VIEW_LABELS[countryData.country]} benchmark with ${scoredRows.toLocaleString()} scored outputs across ${noToolsModels.length} frontier models, ${countryData.programStats.length} programs, and ${Object.keys(countryData.scenarios).length} household scenarios.`;
-  }, [data, isGlobal, noToolsModels]);
+  }, [data, noToolsModels]);
 
   return (
     <div className="min-h-screen bg-void">
@@ -186,30 +157,26 @@ export default function App() {
           />
         </section>
 
-        {!isGlobal && (
-          <>
-            <div className="h-px bg-gradient-to-r from-transparent via-border/40 to-transparent" />
-            <section id="scenarios" className="scroll-mt-20 pt-12 pb-16 sm:pt-16 sm:pb-20">
-              <ScenarioExplorer
-                key={(data as BenchData).country}
-                data={data as BenchData}
-              />
-            </section>
+        <div className="h-px bg-gradient-to-r from-transparent via-border/40 to-transparent" />
+        <section id="scenarios" className="scroll-mt-20 pt-12 pb-16 sm:pt-16 sm:pb-20">
+          <ScenarioExplorer
+            key={data.country}
+            data={data}
+          />
+        </section>
 
-            <div className="h-px bg-gradient-to-r from-transparent via-border/40 to-transparent" />
-            <section
-              id="failure-modes"
-              className="scroll-mt-20 pt-12 pb-16 sm:pt-16 sm:pb-20"
-            >
-              <FailureModes data={data as BenchData} />
-            </section>
+        <div className="h-px bg-gradient-to-r from-transparent via-border/40 to-transparent" />
+        <section
+          id="failure-modes"
+          className="scroll-mt-20 pt-12 pb-16 sm:pt-16 sm:pb-20"
+        >
+          <FailureModes data={data} />
+        </section>
 
-            <div className="h-px bg-gradient-to-r from-transparent via-border/40 to-transparent" />
-            <section id="programs" className="scroll-mt-20 pt-12 pb-16 sm:pt-16 sm:pb-20">
-              <ProgramHeatmap data={data as BenchData} />
-            </section>
-          </>
-        )}
+        <div className="h-px bg-gradient-to-r from-transparent via-border/40 to-transparent" />
+        <section id="programs" className="scroll-mt-20 pt-12 pb-16 sm:pt-16 sm:pb-20">
+          <ProgramHeatmap data={data} />
+        </section>
 
         <div className="h-px bg-gradient-to-r from-transparent via-border/40 to-transparent" />
         <section id="methodology" className="scroll-mt-20 pt-12 pb-16 sm:pt-16 sm:pb-20">

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -31,6 +31,10 @@ const COUNTRY_NAV_ITEMS = [
 ] as const;
 
 const COUNTRY_ORDER: CountryCode[] = ["us", "uk"];
+const COUNTRY_ROUTE_HREFS: Record<CountryCode, string> = {
+  us: "/us",
+  uk: "/uk",
+};
 
 function getAvailableViews(dashboard: DashboardBundle): CountryCode[] {
   return COUNTRY_ORDER.filter((country) => dashboard.countries[country]);
@@ -62,34 +66,45 @@ function detectVisitorCountry(availableViews: readonly CountryCode[]): CountryCo
   return availableViews.includes("us") ? "us" : (availableViews[0] ?? "us");
 }
 
-export default function App() {
+export default function App({ initialView }: { initialView?: CountryCode } = {}) {
   const availableViews = useMemo(() => getAvailableViews(dashboard), []);
   // Default to the US benchmark, then switch UK visitors after mount when
   // timezone or browser language gives us a clear signal.
-  const initialView: CountryCode = availableViews.includes("us")
+  const defaultView: CountryCode = availableViews.includes("us")
     ? "us"
     : (availableViews[0] ?? "us");
-  const [selectedView, setSelectedView] = useState<CountryCode>(initialView);
+  const routeView =
+    initialView && availableViews.includes(initialView) ? initialView : null;
+  const [localView, setLocalView] = useState<CountryCode>(
+    routeView ?? defaultView,
+  );
+  const selectedView = routeView ?? localView;
   const [hasUserPickedView, setHasUserPickedView] = useState(false);
   const [selectedPrograms, setSelectedPrograms] = useState<Set<string>>(
     () => new Set(),
   );
+  const [activeNav, setActiveNav] = useState<string>("models");
+  const observerRef = useRef<IntersectionObserver | null>(null);
 
   useEffect(() => {
+    if (routeView) return;
     if (hasUserPickedView) return;
     const detected = detectVisitorCountry(availableViews);
-    if (detected !== selectedView) {
-      setSelectedView(detected);
+    if (detected !== localView) {
+      setLocalView(detected);
     }
     // We only want this auto-pick to run once per session; further changes
     // come from the user clicking the country selector.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
-  const [activeNav, setActiveNav] = useState<string>("models");
-  const observerRef = useRef<IntersectionObserver | null>(null);
 
   const data = dashboard.countries[selectedView]!;
   const navItems = COUNTRY_NAV_ITEMS;
+  const viewHrefs = useMemo(() => {
+    return Object.fromEntries(
+      availableViews.map((view) => [view, COUNTRY_ROUTE_HREFS[view]]),
+    ) as Partial<Record<ViewKey, string>>;
+  }, [availableViews]);
 
   const programOptions = useMemo(() => buildProgramOptions(data), [data]);
 
@@ -126,7 +141,7 @@ export default function App() {
 
   const handleSelectView = (view: ViewKey) => {
     if (view === "global") return;
-    setSelectedView(view);
+    setLocalView(view);
     setHasUserPickedView(true);
     setActiveNav("models");
   };
@@ -183,6 +198,7 @@ export default function App() {
         dashboard={dashboard}
         data={data}
         availableViews={availableViews}
+        viewHrefs={viewHrefs}
         navItems={navItems}
         activeNav={activeNav}
       />

--- a/app/src/app/layout.tsx
+++ b/app/src/app/layout.tsx
@@ -8,6 +8,14 @@ export const metadata: Metadata = {
   },
   description:
     "Benchmarking no-tools policy calculation across frontier models.",
+  icons: {
+    icon: [
+      {
+        url: "/assets/policyengine-mark.svg",
+        type: "image/svg+xml",
+      },
+    ],
+  },
 };
 
 export default function RootLayout({

--- a/app/src/app/uk/page.tsx
+++ b/app/src/app/uk/page.tsx
@@ -1,0 +1,10 @@
+import type { Metadata } from "next";
+import App from "../../App";
+
+export const metadata: Metadata = {
+  title: "United Kingdom",
+};
+
+export default function UnitedKingdomPage() {
+  return <App initialView="uk" />;
+}

--- a/app/src/app/us/page.tsx
+++ b/app/src/app/us/page.tsx
@@ -1,0 +1,10 @@
+import type { Metadata } from "next";
+import App from "../../App";
+
+export const metadata: Metadata = {
+  title: "United States",
+};
+
+export default function UnitedStatesPage() {
+  return <App initialView="us" />;
+}

--- a/app/src/components/FailureModes.tsx
+++ b/app/src/components/FailureModes.tsx
@@ -118,7 +118,7 @@ export default function FailureModes({ data }: { data: BenchData }) {
         style={{ animationDelay: "240ms" }}
       >
         <div className="text-[10px] uppercase tracking-[0.14em] text-text-muted font-medium">
-          Read this carefully
+          How to read these cards
         </div>
         <p className="mt-3 text-sm leading-relaxed text-text-secondary">
           These cards are intentionally stricter than the aggregate leaderboard but

--- a/app/src/components/FailureModes.tsx
+++ b/app/src/components/FailureModes.tsx
@@ -1,7 +1,6 @@
 import type {
   BenchData,
   FailureModesPayload,
-  HouseholdFailure,
   ProgramFailure,
 } from "../types";
 import { getVariableLabel } from "../types";
@@ -74,25 +73,10 @@ function ProgramCard({
   );
 }
 
-function HouseholdChip({ household }: { household: HouseholdFailure }) {
-  return (
-    <div className="rounded-2xl border border-border bg-surface px-4 py-3">
-      <div className="text-text text-sm">{household.label}</div>
-      <div className="mt-1 flex items-center justify-between gap-3 text-xs">
-        <span className="text-text-muted">{household.n.toLocaleString()} scored rows</span>
-        <span className="text-danger font-[family-name:var(--font-mono)]">
-          {formatPct(household.correctPct)}
-        </span>
-      </div>
-    </div>
-  );
-}
-
 export default function FailureModes({ data }: { data: BenchData }) {
   const country = data.country;
   const failureModes: FailureModesPayload = data.failureModes;
   const hardestPrograms = [...failureModes.programs].slice(0, 10);
-  const hardestHouseholds = [...failureModes.households].slice(0, 7);
 
   return (
     <div>
@@ -141,20 +125,6 @@ export default function FailureModes({ data }: { data: BenchData }) {
             <ProgramCard program={program} country={country} />
           </div>
         ))}
-      </div>
-
-      <div
-        className="mt-10 animate-fade-up"
-        style={{ animationDelay: "520ms" }}
-      >
-        <div className="text-[10px] uppercase tracking-[0.14em] text-text-muted font-medium">
-          Hardest household segments
-        </div>
-        <div className="mt-4 grid md:grid-cols-2 xl:grid-cols-3 gap-3">
-          {hardestHouseholds.map((household) => (
-            <HouseholdChip key={household.label} household={household} />
-          ))}
-        </div>
       </div>
     </div>
   );

--- a/app/src/components/FailureModes.tsx
+++ b/app/src/components/FailureModes.tsx
@@ -1,13 +1,20 @@
+import { useMemo } from "react";
 import type {
   BenchData,
   FailureModesPayload,
+  HeatmapEntry,
   ProgramFailure,
 } from "../types";
 import { getVariableLabel } from "../types";
+import { getVariableExplainer } from "../variableExplainers";
 
 function formatPct(value?: number | null) {
   if (value == null || Number.isNaN(value)) return "n/a";
   return `${value.toFixed(1)}%`;
+}
+
+function getHeatmapScore(entry: HeatmapEntry): number {
+  return entry.score ?? entry.within10pct ?? entry.accuracy ?? 0;
 }
 
 function StatLine({
@@ -73,10 +80,101 @@ function ProgramCard({
   );
 }
 
+function ErrorReadPatterns({
+  data,
+  variables,
+}: {
+  data: BenchData;
+  variables: string[];
+}) {
+  const averageScores = useMemo(() => {
+    const valuesByVariable: Record<string, number[]> = {};
+    for (const entry of data.heatmap) {
+      if (entry.condition !== "no_tools" || !variables.includes(entry.variable)) {
+        continue;
+      }
+      if (!valuesByVariable[entry.variable]) valuesByVariable[entry.variable] = [];
+      valuesByVariable[entry.variable].push(getHeatmapScore(entry));
+    }
+    return Object.fromEntries(
+      Object.entries(valuesByVariable).map(([variable, values]) => [
+        variable,
+        values.reduce((sum, value) => sum + value, 0) / values.length,
+      ]),
+    );
+  }, [data.heatmap, variables]);
+
+  return (
+    <div className="mt-10">
+      <div className="text-[10px] uppercase tracking-[0.14em] text-text-muted font-medium">
+        What the error reads show
+      </div>
+      <p className="mt-3 max-w-3xl text-sm leading-relaxed text-text-secondary">
+        These expanders summarize recurring miss patterns from direct reads of
+        model answers and explanations. They sit here with failure modes because
+        they describe why the low-scoring program slices break.
+      </p>
+
+      <div className="mt-5 space-y-3">
+        {variables.map((variable) => {
+          const explainer = getVariableExplainer(data.country, variable);
+          const avg = averageScores[variable];
+          return (
+            <details
+              key={variable}
+              className="card px-5 py-4 open:border-primary/30 group"
+            >
+              <summary className="flex cursor-pointer list-none items-start justify-between gap-4">
+                <div className="min-w-0 flex items-start gap-2">
+                  <span
+                    aria-hidden
+                    className="mt-0.5 inline-block text-text-muted transition-transform group-open:rotate-90"
+                  >
+                    ▸
+                  </span>
+                  <div className="min-w-0">
+                    <div className="text-text text-sm font-medium">
+                      {getVariableLabel(variable, data.country)}
+                    </div>
+                    <p className="mt-1 text-sm leading-relaxed text-text-secondary">
+                      {explainer?.summary ??
+                        "This target combines multiple policy rules, and errors usually come from positive cases rather than zero cases."}
+                    </p>
+                  </div>
+                </div>
+                {avg !== undefined && (
+                  <div className="shrink-0 rounded-full border border-border bg-surface px-3 py-1 text-[10px] uppercase tracking-[0.14em] text-text-muted font-medium">
+                    Avg {avg.toFixed(0)}%
+                  </div>
+                )}
+              </summary>
+
+              <div className="mt-4 border-t border-border-subtle pt-4">
+                <div className="text-[10px] uppercase tracking-[0.14em] text-text-muted font-medium">
+                  Common misses
+                </div>
+                <ul className="mt-3 space-y-2 text-sm leading-relaxed text-text-secondary">
+                  {(explainer?.bullets ?? []).map((bullet) => (
+                    <li key={bullet} className="flex gap-2">
+                      <span className="mt-[0.45rem] h-1.5 w-1.5 shrink-0 rounded-full bg-primary/70" />
+                      <span>{bullet}</span>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            </details>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
 export default function FailureModes({ data }: { data: BenchData }) {
   const country = data.country;
   const failureModes: FailureModesPayload = data.failureModes;
   const hardestPrograms = [...failureModes.programs].slice(0, 10);
+  const errorReadVariables = hardestPrograms.map((program) => program.variable);
 
   return (
     <div>
@@ -126,6 +224,8 @@ export default function FailureModes({ data }: { data: BenchData }) {
           </div>
         ))}
       </div>
+
+      <ErrorReadPatterns data={data} variables={errorReadVariables} />
     </div>
   );
 }

--- a/app/src/components/Hero.tsx
+++ b/app/src/components/Hero.tsx
@@ -16,6 +16,7 @@ export default function Hero({
   availableViews,
   navItems,
   activeNav,
+  viewHrefs,
 }: {
   selectedView: ViewKey;
   onSelectView: (view: ViewKey) => void;
@@ -24,6 +25,7 @@ export default function Hero({
   availableViews: ViewKey[];
   navItems: readonly HeaderNavItem[];
   activeNav: string;
+  viewHrefs?: Partial<Record<ViewKey, string>>;
 }) {
   const isGlobal = selectedView === "global";
   const benchData = isGlobal ? null : (data as BenchData);
@@ -72,6 +74,7 @@ export default function Hero({
         selectedView={selectedView}
         onSelectView={onSelectView}
         availableViews={availableViews}
+        viewHrefs={viewHrefs}
         actionLink={{ label: "Paper", href: "/paper", type: "internal" }}
       />
 

--- a/app/src/components/Hero.tsx
+++ b/app/src/components/Hero.tsx
@@ -81,7 +81,7 @@ export default function Hero({
       >
         <div
           aria-hidden
-          className="absolute inset-x-0 top-0 h-[320px] bg-[radial-gradient(circle_at_top,_color-mix(in_srgb,var(--color-primary)_13%,transparent),transparent_58%)] pointer-events-none -z-10"
+          className="absolute inset-x-0 top-0 h-[320px] bg-[radial-gradient(ellipse_70%_100%_at_top,_color-mix(in_srgb,var(--color-primary)_13%,transparent)_0%,transparent_70%)] pointer-events-none -z-10"
         />
         <div className="max-w-7xl mx-auto px-4 sm:px-6 pt-10 pb-10 sm:pt-14 sm:pb-12">
           <span

--- a/app/src/components/Methodology.tsx
+++ b/app/src/components/Methodology.tsx
@@ -255,11 +255,8 @@ export default function Methodology({
           and coverage outputs that can plausibly be estimated from household
           facts. It excludes intermediate tax bases, payroll subcomponents, and
           outputs that mainly require unavailable history, restricted local
-          market data, or program take-up assignment. ACA Premium Tax Credit is
-          retained as a deliberate health-support output; when local benchmark
-          premiums are not listed, the model must estimate them from the
-          household facts. WIC is scored as person-level eligibility, not as a
-          dollar amount.
+          market data, or program take-up assignment. WIC is scored as
+          person-level eligibility, not as a dollar amount.
         </SectionCard>
 
         <SectionCard title="Scoring and weighting">

--- a/app/src/components/ModelLeaderboard.tsx
+++ b/app/src/components/ModelLeaderboard.tsx
@@ -15,6 +15,7 @@ import {
   viewSupportsSelected,
   type SensitivityViewId,
 } from "../lib/sensitivity";
+import { outputGroupForVariable } from "../lib/scoring";
 
 function Badge({
   children,
@@ -99,6 +100,20 @@ const PENDING_MODELS: Record<ViewKey, PendingModel[]> = {
   ],
   uk: [],
 };
+
+function weightForVariable(
+  weights: Record<string, number>,
+  variable: string,
+): number | undefined {
+  if (weights[variable] !== undefined) return weights[variable];
+  let groupedWeight = 0;
+  for (const [weightVariable, weight] of Object.entries(weights)) {
+    if (outputGroupForVariable(weightVariable) === variable) {
+      groupedWeight += weight;
+    }
+  }
+  return groupedWeight > 0 ? groupedWeight : undefined;
+}
 
 export default function ModelLeaderboard({
   data,
@@ -242,7 +257,7 @@ export default function ModelLeaderboard({
         let num = 0;
         let den = 0;
         for (const [variable, rates] of byVar) {
-          const w = weights[variable];
+          const w = weightForVariable(weights, variable);
           if (w === undefined) continue;
           num += w * (rates[field] / 100);
           den += w;
@@ -263,7 +278,7 @@ export default function ModelLeaderboard({
       if (entry.condition !== "no_tools") continue;
       const value = entry[field];
       if (value === undefined) continue;
-      const w = weights[entry.variable];
+      const w = weightForVariable(weights, entry.variable);
       if (w === undefined) continue;
       const acc = totals.get(entry.model) ?? { num: 0, den: 0 };
       acc.num += w * (value / 100);

--- a/app/src/components/ModelLeaderboard.tsx
+++ b/app/src/components/ModelLeaderboard.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import type {
   BenchData,
   DashboardBundle,
@@ -9,13 +9,18 @@ import type {
 import { VIEW_SHORT_LABELS, getVariableLabel } from "../types";
 import { MODEL_LABELS, MODEL_ORDER, getProviderForModel } from "../modelMeta";
 import ProviderMark from "./ProviderMark";
+import ProgramFilterDropdown from "./ProgramFilterDropdown";
+import {
+  programIsActive,
+  type ProgramOption,
+  weightedProgramScore,
+} from "../lib/programFilters";
 import {
   SENSITIVITY_VIEWS,
   modelScoresForView,
   viewSupportsSelected,
   type SensitivityViewId,
 } from "../lib/sensitivity";
-import { outputGroupForVariable } from "../lib/scoring";
 
 function Badge({
   children,
@@ -101,28 +106,26 @@ const PENDING_MODELS: Record<ViewKey, PendingModel[]> = {
   uk: [],
 };
 
-function weightForVariable(
-  weights: Record<string, number>,
-  variable: string,
-): number | undefined {
-  if (weights[variable] !== undefined) return weights[variable];
-  let groupedWeight = 0;
-  for (const [weightVariable, weight] of Object.entries(weights)) {
-    if (outputGroupForVariable(weightVariable) === variable) {
-      groupedWeight += weight;
-    }
-  }
-  return groupedWeight > 0 ? groupedWeight : undefined;
-}
-
 export default function ModelLeaderboard({
   data,
   selectedView,
   dashboard,
+  programOptions,
+  activeProgramIds,
+  activeProgramSummary,
+  onResetPrograms,
+  onToggleProgram,
+  onSelectOnlyProgram,
 }: {
   data: BenchData | GlobalBenchData;
   selectedView: ViewKey;
   dashboard: DashboardBundle;
+  programOptions: ProgramOption[];
+  activeProgramIds: Set<string>;
+  activeProgramSummary: string;
+  onResetPrograms: () => void;
+  onToggleProgram: (variable: string) => void;
+  onSelectOnlyProgram: (variable: string) => void;
 }) {
   const isGlobal = selectedView === "global";
   const [sensitivityView, setSensitivityView] =
@@ -142,7 +145,6 @@ export default function ModelLeaderboard({
   const [referenceFilter, setReferenceFilter] = useState<
     "all" | "positives" | "zeros"
   >("all");
-
   // Defensive: if a model's payload doesn't include the requested view (stale
   // data.json), fall back to the canonical Household view so the leaderboard
   // still has a defensible ranking.
@@ -167,6 +169,12 @@ export default function ModelLeaderboard({
     return out;
   }, [sensitivityScores]);
 
+  const isProgramActive = useCallback(
+    (variable: string) =>
+      isGlobal || programIsActive(activeProgramIds, variable),
+    [activeProgramIds, isGlobal],
+  );
+
   // When the user filters to "positives" or "zeros", the heatmap's pre-
   // aggregated `exact`/`within1pct`/`score` columns aren't usable because
   // they don't distinguish reference type. Recompute per-(model, variable)
@@ -188,6 +196,7 @@ export default function ModelLeaderboard({
     >();
     for (const varMap of Object.values(country.scenarioPredictions ?? {})) {
       for (const [variable, modelMap] of Object.entries(varMap)) {
+        if (!isProgramActive(variable)) continue;
         for (const [model, pred] of Object.entries(modelMap)) {
           if (pred.prediction === null) continue;
           const truth = pred.groundTruth;
@@ -234,7 +243,7 @@ export default function ModelLeaderboard({
       out.set(model, rates);
     }
     return out;
-  }, [data, isGlobal, referenceFilter]);
+  }, [data, isGlobal, referenceFilter, isProgramActive]);
 
   // Compute weighted hit-rate for one model under the current weighting. We
   // use this for both "exact" (uses heatmap.exact) and "within 1%" (uses
@@ -254,39 +263,31 @@ export default function ModelLeaderboard({
     if (referenceFilter !== "all") {
       // Recomputed per-(model, variable) hit rates: weight by globalWeights.
       for (const [model, byVar] of filteredHitRates) {
-        let num = 0;
-        let den = 0;
-        for (const [variable, rates] of byVar) {
-          const w = weightForVariable(weights, variable);
-          if (w === undefined) continue;
-          num += w * (rates[field] / 100);
-          den += w;
-        }
-        if (den > 0) out.set(model, (num / den) * 100);
+        const score = weightedProgramScore(
+          [...byVar].map(([variable, rates]) => ({
+            variable,
+            value: rates[field],
+          })),
+          weights,
+        );
+        if (score !== undefined) out.set(model, score);
       }
       return out;
     }
 
-    if (field === "continuous") {
-      // For "all" + continuous, the precomputed sensitivity score is
-      // canonical; the caller uses it directly via sensitivityScoreByModel.
-      return out;
-    }
-
-    const totals = new Map<string, { num: number; den: number }>();
+    const ratesByModel = new Map<string, { variable: string; value: number }[]>();
     for (const entry of country.heatmap ?? []) {
       if (entry.condition !== "no_tools") continue;
-      const value = entry[field];
+      if (!isProgramActive(entry.variable)) continue;
+      const value = field === "continuous" ? entry.score : entry[field];
       if (value === undefined) continue;
-      const w = weightForVariable(weights, entry.variable);
-      if (w === undefined) continue;
-      const acc = totals.get(entry.model) ?? { num: 0, den: 0 };
-      acc.num += w * (value / 100);
-      acc.den += w;
-      totals.set(entry.model, acc);
+      const rates = ratesByModel.get(entry.model) ?? [];
+      rates.push({ variable: entry.variable, value });
+      ratesByModel.set(entry.model, rates);
     }
-    for (const [model, { num, den }] of totals) {
-      if (den > 0) out.set(model, (num / den) * 100);
+    for (const [model, rates] of ratesByModel) {
+      const score = weightedProgramScore(rates, weights);
+      if (score !== undefined) out.set(model, score);
     }
     return out;
   };
@@ -294,18 +295,62 @@ export default function ModelLeaderboard({
   const exactScoreByModel = useMemo(
     () => hitRateByModel("exact"),
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [data, effectiveView, isGlobal, referenceFilter, filteredHitRates],
+    [
+      data,
+      effectiveView,
+      isGlobal,
+      referenceFilter,
+      filteredHitRates,
+      activeProgramIds,
+    ],
   );
   const within1pctScoreByModel = useMemo(
     () => hitRateByModel("within1pct"),
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [data, effectiveView, isGlobal, referenceFilter, filteredHitRates],
+    [
+      data,
+      effectiveView,
+      isGlobal,
+      referenceFilter,
+      filteredHitRates,
+      activeProgramIds,
+    ],
   );
   const filteredContinuousByModel = useMemo(
     () => hitRateByModel("continuous"),
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [data, effectiveView, isGlobal, referenceFilter, filteredHitRates],
+    [
+      data,
+      effectiveView,
+      isGlobal,
+      referenceFilter,
+      filteredHitRates,
+      activeProgramIds,
+    ],
   );
+
+  const selectedMaeByModel = useMemo(() => {
+    const out = new Map<string, number>();
+    if (isGlobal || !("scenarioPredictions" in data)) return out;
+    const totals = new Map<string, { sum: number; n: number }>();
+    for (const variableMap of Object.values(data.scenarioPredictions)) {
+      for (const [variable, modelMap] of Object.entries(variableMap)) {
+        if (!isProgramActive(variable)) continue;
+        for (const [model, row] of Object.entries(modelMap)) {
+          if (row.prediction === null || row.prediction === undefined) continue;
+          const acc = totals.get(model) ?? { sum: 0, n: 0 };
+          acc.sum += Math.abs(row.prediction - row.groundTruth);
+          acc.n += 1;
+          totals.set(model, acc);
+        }
+      }
+    }
+    for (const [model, { sum, n }] of totals) {
+      if (n > 0) out.set(model, sum / n);
+    }
+    return out;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [data, isGlobal, activeProgramIds]);
 
   const noTools = useMemo<ModelStat[]>(() => {
     const base = data.modelStats.filter((m) => m.condition === "no_tools");
@@ -324,19 +369,24 @@ export default function ModelLeaderboard({
           const w = weighted.get(m.model);
           const fallback =
             scoringMode === "exact" ? (m.exact ?? 0) : (m.within1pct ?? 0);
-          return { ...m, score: w !== undefined ? w : fallback };
+          return {
+            ...m,
+            score: w !== undefined ? w : fallback,
+            mae: selectedMaeByModel.get(m.model) ?? m.mae,
+          };
         })
         .sort((a, b) => b.score - a.score);
     }
 
-    // Continuous mode. When filtering to positives/zeros we use the
-    // recomputed weighted score; otherwise fall back to the precomputed
-    // bounded score (Household weighting) or the sensitivity view.
-    if (referenceFilter !== "all") {
+    // Continuous mode. Use the recomputed weighted score for country views so
+    // program filters renormalize the active program weights; otherwise fall
+    // back to the precomputed bounded score or global sensitivity view.
+    if (!isGlobal && filteredContinuousByModel.size > 0) {
       return [...base]
         .map((m) => ({
           ...m,
           score: filteredContinuousByModel.get(m.model) ?? 0,
+          mae: selectedMaeByModel.get(m.model) ?? m.mae,
         }))
         .sort((a, b) => b.score - a.score);
     }
@@ -354,10 +404,11 @@ export default function ModelLeaderboard({
     effectiveView,
     sensitivityScoreByModel,
     filteredContinuousByModel,
-    referenceFilter,
     exactScoreByModel,
     within1pctScoreByModel,
+    selectedMaeByModel,
     scoringMode,
+    isGlobal,
   ]);
 
   const pendingModels = useMemo<PendingModel[]>(() => {
@@ -386,7 +437,11 @@ export default function ModelLeaderboard({
     const all = new Set<string>();
     for (const view of ["household", "aggregate", "equal"] as const) {
       const map = weights[view];
-      if (map) Object.keys(map).forEach((v) => all.add(v));
+      if (map) {
+        Object.keys(map)
+          .filter(isProgramActive)
+          .forEach((v) => all.add(v));
+      }
     }
     const ranked = Array.from(all).map((v) => ({
       v,
@@ -394,7 +449,7 @@ export default function ModelLeaderboard({
     }));
     ranked.sort((a, b) => b.key - a.key);
     return ranked.map((r) => r.v);
-  }, [weights, effectiveView]);
+  }, [weights, effectiveView, isProgramActive]);
 
   return (
     <div>
@@ -441,6 +496,18 @@ export default function ModelLeaderboard({
           evaluation set.
         </p>
       </aside>
+
+      <ProgramFilterDropdown
+        options={isGlobal ? [] : programOptions}
+        activeProgramIds={activeProgramIds}
+        summary={activeProgramSummary}
+        description="Shared across model scoring, program breakdown, and scenarios. Scores use only selected outputs; selected weights rescale to 100%. MAE is the unweighted average absolute error across selected scenario cells."
+        onReset={onResetPrograms}
+        onToggle={onToggleProgram}
+        onSelectOnly={onSelectOnlyProgram}
+        className="mt-5"
+        animationDelay="190ms"
+      />
 
       <div
         role="region"

--- a/app/src/components/ModelLeaderboard.tsx
+++ b/app/src/components/ModelLeaderboard.tsx
@@ -411,8 +411,8 @@ export default function ModelLeaderboard({
         style={{ animationDelay: "160ms" }}
       >
         {isGlobal
-          ? "Global scores are equal-weight averages of each model’s US and UK bounded scores. They are not weighted by country population or household count."
-          : "Country scores give each household equal weight. Each variable's weight is the mean across households of |ref| / max(|household_net_income|, Σ |ref|), renormalized so the global weights sum to one."}
+          ? "Default ranking compares each model's exact answers across the US and UK benchmark slices."
+          : "Default ranking compares exact answers across all benchmark households, with one household counting as one household."}
         {pendingModels.length > 0 && (
           <>
             {" "}
@@ -441,202 +441,6 @@ export default function ModelLeaderboard({
           evaluation set.
         </p>
       </aside>
-
-      <div
-        className="mt-5 flex flex-wrap items-center gap-3 animate-fade-up"
-        style={{ animationDelay: "195ms" }}
-      >
-        <span
-          id="leaderboard-scoring-label"
-          className="text-[10px] font-medium uppercase tracking-[0.14em] text-text-muted"
-        >
-          Scoring
-        </span>
-        <div
-          role="group"
-          aria-labelledby="leaderboard-scoring-label"
-          className="inline-flex flex-wrap items-center gap-1 rounded-full border border-border bg-card p-1"
-        >
-          {(
-            [
-              [
-                "exact",
-                "Exact",
-                "Percent of predictions that match the PolicyEngine reference to the dollar (or to the boolean for eligibility flags). Real-world policy decisions need this — close-but-not-right isn't deployable.",
-              ],
-              [
-                "within1pct",
-                "Within 1%",
-                "Percent of predictions within 1% of the reference. The analyst bar — rounding and small rate/parameter drift are tolerated, but material misses are not.",
-              ],
-              [
-                "continuous",
-                "Continuous",
-                "Bounded continuous score: max(0, 1 - |prediction - reference| / |reference|), clipped to [0, 1], reducing to exact-match accuracy for boolean variables. Awards partial credit for close answers; useful for tracking conceptual progress while exact rates remain low.",
-              ],
-            ] as const
-          ).map(([id, label, description]) => {
-            const isActive = scoringMode === id;
-            return (
-              <button
-                key={id}
-                type="button"
-                onClick={() => setScoringMode(id)}
-                aria-pressed={isActive}
-                title={description}
-                className={`rounded-full px-3 py-1.5 text-[11px] font-medium transition-colors ${
-                  isActive
-                    ? "bg-primary-strong text-white"
-                    : "text-text-secondary hover:text-text"
-                }`}
-              >
-                {label}
-              </button>
-            );
-          })}
-        </div>
-        <span className="text-[11px] text-text-muted">
-          {scoringMode === "exact"
-            ? "Percent matching to the dollar / boolean."
-            : scoringMode === "within1pct"
-              ? "Percent within 1% of reference."
-              : "Bounded score: 1 − |err| / |ref|, clipped to [0, 1]."}
-        </span>
-      </div>
-
-      {!isGlobal && (
-        <div
-          className="mt-3 flex flex-wrap items-center gap-3 animate-fade-up"
-          style={{ animationDelay: "198ms" }}
-        >
-          <span
-            id="leaderboard-refcases-label"
-            className="text-[10px] font-medium uppercase tracking-[0.14em] text-text-muted"
-          >
-            Reference cases
-          </span>
-          <div
-            role="group"
-            aria-labelledby="leaderboard-refcases-label"
-            className="inline-flex flex-wrap items-center gap-1 rounded-full border border-border bg-card p-1"
-          >
-            {(
-              [
-                [
-                  "all",
-                  "All",
-                  "Every (model, scenario, variable) cell in the benchmark slice.",
-                ],
-                [
-                  "positives",
-                  "Positives only",
-                  "Restrict to cases where the PolicyEngine reference is non-zero (e.g., the household actually receives the benefit or owes the tax). Reveals competence on cases that matter, especially on zero-heavy slices like UK.",
-                ],
-                [
-                  "zeros",
-                  "Zeros only",
-                  "Restrict to cases where the PolicyEngine reference is zero (no benefit, no tax). Measures eligibility hedging — does the model correctly say zero when it should?",
-                ],
-              ] as const
-            ).map(([id, label, description]) => {
-              const isActive = referenceFilter === id;
-              return (
-                <button
-                  key={id}
-                  type="button"
-                  onClick={() => setReferenceFilter(id)}
-                  aria-pressed={isActive}
-                  title={description}
-                  className={`rounded-full px-3 py-1.5 text-[11px] font-medium transition-colors ${
-                    isActive
-                      ? "bg-primary-strong text-white"
-                      : "text-text-secondary hover:text-text"
-                  }`}
-                >
-                  {label}
-                </button>
-              );
-            })}
-          </div>
-          <span className="text-[11px] text-text-muted">
-            {referenceFilter === "all"
-              ? "All reference cells."
-              : referenceFilter === "positives"
-                ? "Only cases where the reference is nonzero."
-                : "Only cases where the reference is zero."}
-          </span>
-        </div>
-      )}
-
-      <div
-        className="mt-3 flex flex-wrap items-center gap-3 animate-fade-up"
-        style={{ animationDelay: "200ms" }}
-      >
-        <span
-          id="leaderboard-view-label"
-          className="text-[10px] font-medium uppercase tracking-[0.14em] text-text-muted"
-        >
-          Weighting
-        </span>
-        <div
-          role="group"
-          aria-labelledby="leaderboard-view-label"
-          className="inline-flex flex-wrap items-center gap-1 rounded-full border border-border bg-card p-1"
-        >
-          {SENSITIVITY_VIEWS.map((view) => {
-            const isActive = sensitivityView === view.id;
-            const supported =
-              view.id === "household" ||
-              viewSupportsSelected(dashboard, view.id, selectedView);
-            const disabled = !supported;
-            const disabledTitleSuffix = " (not available on this slice)";
-            return (
-              <button
-                key={view.id}
-                type="button"
-                aria-disabled={disabled || undefined}
-                onClick={(event) => {
-                  if (disabled) {
-                    event.preventDefault();
-                    return;
-                  }
-                  setSensitivityView(view.id);
-                }}
-                aria-pressed={disabled ? undefined : isActive}
-                className={`rounded-full px-3 py-1.5 text-[11px] font-medium transition-colors ${
-                  isActive && !disabled
-                    ? "bg-primary-strong text-white"
-                    : disabled
-                      ? "cursor-not-allowed text-text-muted line-through"
-                      : "text-text-secondary hover:text-text"
-                }`}
-                title={
-                  disabled
-                    ? `${view.description}${disabledTitleSuffix}`
-                    : view.description
-                }
-              >
-                {view.label}
-              </button>
-            );
-          })}
-        </div>
-        <span className="text-[11px] text-text-muted">
-          {activeView.description}
-        </span>
-      </div>
-      {sensitivityUnsupportedForView && (
-        <p
-          className="mt-3 text-[11px] text-text-muted animate-fade-up"
-          style={{ animationDelay: "220ms" }}
-        >
-          The &ldquo;{
-            SENSITIVITY_VIEWS.find((v) => v.id === sensitivityView)?.label ??
-              sensitivityView
-          }&rdquo; view is not available on this slice; the leaderboard falls
-          back to the Household view.
-        </p>
-      )}
 
       <div
         role="region"
@@ -842,10 +646,226 @@ export default function ModelLeaderboard({
         ))}
       </div>
 
+      <details
+        className="mt-8 group rounded-2xl border border-border bg-card/40 animate-fade-up"
+        style={{ animationDelay: "320ms" }}
+      >
+        <summary className="flex cursor-pointer list-none items-center justify-between gap-3 px-4 py-3 text-xs text-text-secondary hover:text-text">
+          <span className="flex min-w-0 items-center gap-2">
+            <svg
+              aria-hidden
+              viewBox="0 0 12 12"
+              width="10"
+              height="10"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              className="shrink-0 transition-transform group-open:rotate-90"
+            >
+              <polyline points="4 2 8 6 4 10" />
+            </svg>
+            <span className="shrink-0 text-[10px] font-medium uppercase tracking-[0.14em] text-text-muted">
+              Adjust ranking
+            </span>
+            <span className="truncate text-text-muted">
+              Default: exact, all cases, household weights
+            </span>
+          </span>
+        </summary>
+
+        <div className="space-y-4 border-t border-border-subtle px-4 py-4">
+          <div className="flex flex-wrap items-center gap-3">
+            <span
+              id="leaderboard-scoring-label"
+              className="text-[10px] font-medium uppercase tracking-[0.14em] text-text-muted"
+            >
+              Scoring
+            </span>
+            <div
+              role="group"
+              aria-labelledby="leaderboard-scoring-label"
+              className="inline-flex flex-wrap items-center gap-1 rounded-full border border-border bg-card p-1"
+            >
+              {(
+                [
+                  [
+                    "exact",
+                    "Exact",
+                    "Percent of predictions that match the PolicyEngine reference to the dollar (or to the boolean for eligibility flags). Real-world policy decisions need this — close-but-not-right isn't deployable.",
+                  ],
+                  [
+                    "within1pct",
+                    "Within 1%",
+                    "Percent of predictions within 1% of the reference. The analyst bar — rounding and small rate/parameter drift are tolerated, but material misses are not.",
+                  ],
+                  [
+                    "continuous",
+                    "Continuous",
+                    "Bounded continuous score: max(0, 1 - |prediction - reference| / |reference|), clipped to [0, 1], reducing to exact-match accuracy for boolean variables. Awards partial credit for close answers; useful for tracking conceptual progress while exact rates remain low.",
+                  ],
+                ] as const
+              ).map(([id, label, description]) => {
+                const isActive = scoringMode === id;
+                return (
+                  <button
+                    key={id}
+                    type="button"
+                    onClick={() => setScoringMode(id)}
+                    aria-pressed={isActive}
+                    title={description}
+                    className={`rounded-full px-3 py-1.5 text-[11px] font-medium transition-colors ${
+                      isActive
+                        ? "bg-primary-strong text-white"
+                        : "text-text-secondary hover:text-text"
+                    }`}
+                  >
+                    {label}
+                  </button>
+                );
+              })}
+            </div>
+            <span className="text-[11px] text-text-muted">
+              {scoringMode === "exact"
+                ? "Percent matching to the dollar / boolean."
+                : scoringMode === "within1pct"
+                  ? "Percent within 1% of reference."
+                  : "Bounded score: 1 - |err| / |ref|, clipped to [0, 1]."}
+            </span>
+          </div>
+
+          {!isGlobal && (
+            <div className="flex flex-wrap items-center gap-3">
+              <span
+                id="leaderboard-refcases-label"
+                className="text-[10px] font-medium uppercase tracking-[0.14em] text-text-muted"
+              >
+                Reference cases
+              </span>
+              <div
+                role="group"
+                aria-labelledby="leaderboard-refcases-label"
+                className="inline-flex flex-wrap items-center gap-1 rounded-full border border-border bg-card p-1"
+              >
+                {(
+                  [
+                    [
+                      "all",
+                      "All",
+                      "Every (model, scenario, variable) cell in the benchmark slice.",
+                    ],
+                    [
+                      "positives",
+                      "Positives only",
+                      "Restrict to cases where the PolicyEngine reference is non-zero (e.g., the household actually receives the benefit or owes the tax). Reveals competence on cases that matter, especially on zero-heavy slices like UK.",
+                    ],
+                    [
+                      "zeros",
+                      "Zeros only",
+                      "Restrict to cases where the PolicyEngine reference is zero (no benefit, no tax). Measures eligibility hedging — does the model correctly say zero when it should?",
+                    ],
+                  ] as const
+                ).map(([id, label, description]) => {
+                  const isActive = referenceFilter === id;
+                  return (
+                    <button
+                      key={id}
+                      type="button"
+                      onClick={() => setReferenceFilter(id)}
+                      aria-pressed={isActive}
+                      title={description}
+                      className={`rounded-full px-3 py-1.5 text-[11px] font-medium transition-colors ${
+                        isActive
+                          ? "bg-primary-strong text-white"
+                          : "text-text-secondary hover:text-text"
+                      }`}
+                    >
+                      {label}
+                    </button>
+                  );
+                })}
+              </div>
+              <span className="text-[11px] text-text-muted">
+                {referenceFilter === "all"
+                  ? "All reference cells."
+                  : referenceFilter === "positives"
+                    ? "Only cases where the reference is nonzero."
+                    : "Only cases where the reference is zero."}
+              </span>
+            </div>
+          )}
+
+          <div className="flex flex-wrap items-center gap-3">
+            <span
+              id="leaderboard-view-label"
+              className="text-[10px] font-medium uppercase tracking-[0.14em] text-text-muted"
+            >
+              Weighting
+            </span>
+            <div
+              role="group"
+              aria-labelledby="leaderboard-view-label"
+              className="inline-flex flex-wrap items-center gap-1 rounded-full border border-border bg-card p-1"
+            >
+              {SENSITIVITY_VIEWS.map((view) => {
+                const isActive = sensitivityView === view.id;
+                const supported =
+                  view.id === "household" ||
+                  viewSupportsSelected(dashboard, view.id, selectedView);
+                const disabled = !supported;
+                const disabledTitleSuffix = " (not available on this slice)";
+                return (
+                  <button
+                    key={view.id}
+                    type="button"
+                    aria-disabled={disabled || undefined}
+                    onClick={(event) => {
+                      if (disabled) {
+                        event.preventDefault();
+                        return;
+                      }
+                      setSensitivityView(view.id);
+                    }}
+                    aria-pressed={disabled ? undefined : isActive}
+                    className={`rounded-full px-3 py-1.5 text-[11px] font-medium transition-colors ${
+                      isActive && !disabled
+                        ? "bg-primary-strong text-white"
+                        : disabled
+                          ? "cursor-not-allowed text-text-muted line-through"
+                          : "text-text-secondary hover:text-text"
+                    }`}
+                    title={
+                      disabled
+                        ? `${view.description}${disabledTitleSuffix}`
+                        : view.description
+                    }
+                  >
+                    {view.label}
+                  </button>
+                );
+              })}
+            </div>
+            <span className="text-[11px] text-text-muted">
+              {activeView.description}
+            </span>
+          </div>
+          {sensitivityUnsupportedForView && (
+            <p className="text-[11px] text-text-muted">
+              The &ldquo;{
+                SENSITIVITY_VIEWS.find((v) => v.id === sensitivityView)?.label ??
+                  sensitivityView
+              }&rdquo; view is not available on this slice; the leaderboard
+              falls back to the Household view.
+            </p>
+          )}
+        </div>
+      </details>
+
       {weights && weightedVariables.length > 0 && weightsCountry && (
         <details
-          className="mt-8 group rounded-2xl border border-border bg-card/40 animate-fade-up"
-          style={{ animationDelay: "320ms" }}
+          className="mt-4 group rounded-2xl border border-border bg-card/40 animate-fade-up"
+          style={{ animationDelay: "340ms" }}
         >
           <summary className="flex cursor-pointer list-none items-center justify-between gap-3 px-4 py-3 text-xs text-text-secondary hover:text-text">
             <span className="flex items-center gap-2">

--- a/app/src/components/ProgramFilterDropdown.tsx
+++ b/app/src/components/ProgramFilterDropdown.tsx
@@ -1,0 +1,107 @@
+import type { ProgramOption } from "../lib/programFilters";
+
+type ProgramFilterDropdownProps = {
+  options: ProgramOption[];
+  activeProgramIds: Set<string>;
+  summary: string;
+  description: string;
+  onReset: () => void;
+  onToggle: (variable: string) => void;
+  onSelectOnly: (variable: string) => void;
+  className?: string;
+  animationDelay?: string;
+};
+
+export default function ProgramFilterDropdown({
+  options,
+  activeProgramIds,
+  summary,
+  description,
+  onReset,
+  onToggle,
+  onSelectOnly,
+  className = "",
+  animationDelay,
+}: ProgramFilterDropdownProps) {
+  if (options.length === 0) return null;
+
+  return (
+    <details
+      className={`group rounded-2xl border border-border bg-card/40 animate-fade-up ${className}`}
+      style={animationDelay ? { animationDelay } : undefined}
+    >
+      <summary className="flex cursor-pointer list-none items-center justify-between gap-3 px-4 py-3 text-xs text-text-secondary hover:text-text">
+        <span className="flex min-w-0 items-center gap-2">
+          <svg
+            aria-hidden
+            viewBox="0 0 12 12"
+            width="10"
+            height="10"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            className="shrink-0 transition-transform group-open:rotate-90"
+          >
+            <polyline points="4 2 8 6 4 10" />
+          </svg>
+          <span className="shrink-0 text-[10px] font-medium uppercase tracking-[0.14em] text-text-muted">
+            Program filter
+          </span>
+          <span className="truncate text-text-muted">{summary}</span>
+        </span>
+      </summary>
+
+      <div className="border-t border-border-subtle px-4 py-4">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <p className="max-w-2xl text-xs leading-relaxed text-text-secondary">
+            {description}
+          </p>
+          <button
+            type="button"
+            onClick={onReset}
+            className="rounded-full border border-border bg-surface px-3 py-1.5 text-[11px] font-medium uppercase tracking-[0.12em] text-text-secondary transition-colors hover:border-primary-strong/40 hover:text-text"
+          >
+            All programs
+          </button>
+        </div>
+
+        <div className="mt-4 grid gap-2 sm:grid-cols-2 lg:grid-cols-3">
+          {options.map((option) => {
+            const checked = activeProgramIds.has(option.variable);
+            return (
+              <div
+                key={option.variable}
+                className={`flex min-w-0 items-center gap-2 rounded-lg border px-3 py-2 transition-colors ${
+                  checked
+                    ? "border-primary-strong/30 bg-primary-soft/50"
+                    : "border-border-subtle bg-surface/60"
+                }`}
+              >
+                <label className="flex min-w-0 flex-1 cursor-pointer items-center gap-2">
+                  <input
+                    type="checkbox"
+                    checked={checked}
+                    onChange={() => onToggle(option.variable)}
+                    className="h-3.5 w-3.5 rounded border-border text-primary-strong"
+                  />
+                  <span className="truncate text-xs text-text-secondary">
+                    {option.label}
+                  </span>
+                </label>
+                <button
+                  type="button"
+                  onClick={() => onSelectOnly(option.variable)}
+                  className="shrink-0 rounded-full border border-border bg-card px-2 py-0.5 text-[10px] font-medium uppercase tracking-[0.12em] text-text-muted transition-colors hover:border-primary-strong/40 hover:text-text"
+                >
+                  Only
+                </button>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </details>
+  );
+}

--- a/app/src/components/ProgramHeatmap.tsx
+++ b/app/src/components/ProgramHeatmap.tsx
@@ -6,6 +6,8 @@ import {
   getPerformanceSurfaceColor,
   getPerformanceTextColor,
 } from "../modelMeta";
+import { programIsActive, type ProgramOption } from "../lib/programFilters";
+import ProgramFilterDropdown from "./ProgramFilterDropdown";
 
 function getHeatmapScore(entry: HeatmapEntry): number {
   return entry.score ?? entry.within10pct ?? entry.accuracy ?? 0;
@@ -28,7 +30,23 @@ const SCORE_LEGEND = [
   { label: "90%+", score: 95 },
 ] as const;
 
-export default function ProgramHeatmap({ data }: { data: BenchData }) {
+export default function ProgramHeatmap({
+  data,
+  programOptions,
+  activeProgramIds,
+  activeProgramSummary,
+  onResetPrograms,
+  onToggleProgram,
+  onSelectOnlyProgram,
+}: {
+  data: BenchData;
+  programOptions: ProgramOption[];
+  activeProgramIds: Set<string>;
+  activeProgramSummary: string;
+  onResetPrograms: () => void;
+  onToggleProgram: (variable: string) => void;
+  onSelectOnlyProgram: (variable: string) => void;
+}) {
   const country = data.country;
   const { grid, variables } = useMemo(() => {
     // Build lookup: model+variable → bounded score
@@ -42,6 +60,7 @@ export default function ProgramHeatmap({ data }: { data: BenchData }) {
     const varAcc: Record<string, number[]> = {};
     for (const h of data.heatmap) {
       if (h.condition !== "no_tools") continue;
+      if (!programIsActive(activeProgramIds, h.variable)) continue;
       if (!varAcc[h.variable]) varAcc[h.variable] = [];
       varAcc[h.variable].push(getHeatmapScore(h));
     }
@@ -52,7 +71,7 @@ export default function ProgramHeatmap({ data }: { data: BenchData }) {
     });
 
     return { grid: lookup, variables };
-  }, [data]);
+  }, [activeProgramIds, data]);
 
   const models = MODEL_ORDER.filter((m) =>
     data.heatmap.some((h) => h.condition === "no_tools" && h.model === m),
@@ -86,8 +105,20 @@ export default function ProgramHeatmap({ data }: { data: BenchData }) {
         binary coverage flags use exact accuracy.
       </p>
 
+      <ProgramFilterDropdown
+        options={programOptions}
+        activeProgramIds={activeProgramIds}
+        summary={activeProgramSummary}
+        description="Shared with model scoring and scenarios. The table shows only selected outputs; model scores rescale selected weights to 100%."
+        onReset={onResetPrograms}
+        onToggle={onToggleProgram}
+        onSelectOnly={onSelectOnlyProgram}
+        className="mt-6"
+        animationDelay="220ms"
+      />
+
       <div
-        className="relative mt-10 overflow-x-auto animate-fade-up"
+        className="relative mt-8 overflow-x-auto animate-fade-up"
         style={{ animationDelay: "240ms" }}
       >
         <table className="w-full border-collapse">

--- a/app/src/components/ProgramHeatmap.tsx
+++ b/app/src/components/ProgramHeatmap.tsx
@@ -6,7 +6,6 @@ import {
   getPerformanceSurfaceColor,
   getPerformanceTextColor,
 } from "../modelMeta";
-import { getVariableExplainer } from "../variableExplainers";
 
 function getHeatmapScore(entry: HeatmapEntry): number {
   return entry.score ?? entry.within10pct ?? entry.accuracy ?? 0;
@@ -19,6 +18,15 @@ function cellColor(pct: number): string {
 function textColor(pct: number): string {
   return getPerformanceTextColor(pct);
 }
+
+const SCORE_LEGEND = [
+  { label: "<50%", score: 45 },
+  { label: "50-59%", score: 55 },
+  { label: "60-69%", score: 65 },
+  { label: "70-79%", score: 75 },
+  { label: "80-89%", score: 85 },
+  { label: "90%+", score: 95 },
+] as const;
 
 export default function ProgramHeatmap({ data }: { data: BenchData }) {
   const country = data.country;
@@ -141,110 +149,25 @@ export default function ProgramHeatmap({ data }: { data: BenchData }) {
         </table>
       </div>
 
-      {/* Legend */}
       <div
         role="list"
         aria-label="Score color scale: cells color-code each row's percent score; the printed percentage in the cell is the source of truth"
-        className="flex items-center gap-6 mt-6 text-[10px] uppercase tracking-[0.14em] text-text-muted"
+        className="mt-6 flex flex-wrap items-center gap-x-5 gap-y-2 text-[10px] uppercase tracking-[0.14em] text-text-muted"
       >
         <span className="sr-only">
           Cells use color as a redundant cue; the percentage shown in each
           cell is the actual benchmark score.
         </span>
-        <div role="listitem" className="flex items-center gap-1.5">
-          <span
-            aria-hidden
-            className="w-3 h-3 rounded"
-            style={{ backgroundColor: cellColor(40) }}
-          />
-          &lt;50%
-        </div>
-        <div role="listitem" className="flex items-center gap-1.5">
-          <span
-            aria-hidden
-            className="w-3 h-3 rounded"
-            style={{ backgroundColor: cellColor(60) }}
-          />
-          50–70%
-        </div>
-        <div role="listitem" className="flex items-center gap-1.5">
-          <span
-            aria-hidden
-            className="w-3 h-3 rounded"
-            style={{ backgroundColor: cellColor(75) }}
-          />
-          70–80%
-        </div>
-        <div role="listitem" className="flex items-center gap-1.5">
-          <span
-            aria-hidden
-            className="w-3 h-3 rounded"
-            style={{ backgroundColor: cellColor(92) }}
-          />
-          90%+
-        </div>
-      </div>
-
-      <div className="mt-10">
-        <div className="text-[10px] uppercase tracking-[0.14em] text-text-muted font-medium">
-          What the error reads show
-        </div>
-        <p className="mt-3 max-w-3xl text-sm leading-relaxed text-text-secondary">
-          These expanders summarize recurring miss patterns from direct reads of
-          model answers and explanations, paired with the benchmark scores
-          above. They are intentionally narrower than the leaderboard summaries:
-          the goal is to say what the evidence supports, not more.
-        </p>
-
-        <div className="mt-5 space-y-3">
-          {variables.map((variable) => {
-            const explainer = getVariableExplainer(country, variable);
-            const avg = averageScores[variable];
-            return (
-              <details
-                key={variable}
-                className="card px-5 py-4 open:border-primary/30 group"
-              >
-                <summary className="flex cursor-pointer list-none items-start justify-between gap-4">
-                  <div className="min-w-0 flex items-start gap-2">
-                    <span
-                      aria-hidden
-                      className="mt-0.5 inline-block text-text-muted transition-transform group-open:rotate-90"
-                    >
-                      ▸
-                    </span>
-                    <div className="min-w-0">
-                      <div className="text-text text-sm font-medium">
-                        {getVariableLabel(variable, country)}
-                      </div>
-                      <p className="mt-1 text-sm leading-relaxed text-text-secondary">
-                        {explainer?.summary ??
-                          "This target combines multiple policy rules, and errors usually come from positive cases rather than zero cases."}
-                      </p>
-                    </div>
-                  </div>
-                  <div className="shrink-0 rounded-full border border-border bg-surface px-3 py-1 text-[10px] uppercase tracking-[0.14em] text-text-muted font-medium">
-                    Avg {avg.toFixed(0)}%
-                  </div>
-                </summary>
-
-                <div className="mt-4 border-t border-border-subtle pt-4">
-                  <div className="text-[10px] uppercase tracking-[0.14em] text-text-muted font-medium">
-                    Common misses
-                  </div>
-                  <ul className="mt-3 space-y-2 text-sm leading-relaxed text-text-secondary">
-                    {(explainer?.bullets ?? []).map((bullet) => (
-                      <li key={bullet} className="flex gap-2">
-                        <span className="mt-[0.45rem] h-1.5 w-1.5 shrink-0 rounded-full bg-primary/70" />
-                        <span>{bullet}</span>
-                      </li>
-                    ))}
-                  </ul>
-                </div>
-              </details>
-            );
-          })}
-        </div>
+        {SCORE_LEGEND.map(({ label, score }) => (
+          <div key={label} role="listitem" className="flex items-center gap-1.5">
+            <span
+              aria-hidden
+              className="h-3 w-3 rounded"
+              style={{ backgroundColor: cellColor(score) }}
+            />
+            {label}
+          </div>
+        ))}
       </div>
     </div>
   );

--- a/app/src/components/ScenarioExplorer.tsx
+++ b/app/src/components/ScenarioExplorer.tsx
@@ -232,9 +232,8 @@ export default function ScenarioExplorer({
         className="text-text-secondary mt-3 max-w-2xl leading-relaxed animate-fade-up"
         style={{ animationDelay: "160ms" }}
       >
-        Inspect benchmark households and the exact prompt sent to every model.
-        Click any prediction cell to see the model&apos;s reasoning and our
-        review of where it went wrong.
+        Inspect benchmark households, reference outputs, model answers, and the
+        exact prompt sent to every model.
       </p>
 
       <div className="mt-8 flex flex-wrap items-end gap-4">
@@ -319,99 +318,6 @@ export default function ScenarioExplorer({
           </div>
         ))}
       </div>
-
-      {totalPredictionRows > 0 && (
-        <div
-          className="card px-5 py-4 mt-4 animate-fade-up"
-          style={{ animationDelay: "260ms" }}
-        >
-          <div className="text-[10px] uppercase tracking-[0.14em] text-text-muted font-medium">
-            Explanation and audit coverage
-          </div>
-          <p className="mt-2 text-sm text-text-secondary leading-relaxed">
-            {explanationRows} of {totalPredictionRows} model-output rows for
-            this household include explanation text returned by the model.{" "}
-            {annotationRows} rows include developer audit notes for incorrect
-            predictions, and {caseAnnotationRows} incorrect rows include
-            case-level notes comparing wrong models on the same
-            household-output target. Click a prediction cell to read them
-            below the table.
-          </p>
-          {Object.keys(failureSources).length > 0 && (
-            <div className="mt-3 flex flex-wrap gap-2">
-              {Object.entries(failureSources)
-                .sort((a, b) => b[1] - a[1])
-                .map(([source, count]) => (
-                  <span
-                    key={source}
-                    className="rounded-full border border-border-subtle bg-surface px-2.5 py-1 text-[11px] text-text-secondary"
-                  >
-                    {formatFailureLabel(source)}: {count}
-                  </span>
-                ))}
-            </div>
-          )}
-        </div>
-      )}
-
-      {activePrompt && (
-        <details
-          className="card px-5 py-4 mt-6 animate-fade-up group"
-          style={{ animationDelay: "280ms" }}
-        >
-          <summary className="cursor-pointer list-none flex flex-wrap items-center justify-between gap-3">
-            <div className="flex items-start gap-2">
-              <span
-                aria-hidden
-                className="mt-0.5 inline-block text-text-muted transition-transform group-open:rotate-90"
-              >
-                ▸
-              </span>
-              <div>
-                <div className="text-[10px] uppercase tracking-[0.14em] text-text-muted font-medium">
-                  Exact prompt
-                </div>
-                <div className="text-text text-sm mt-1">
-                  Full household batch contract for all benchmark outputs
-                </div>
-              </div>
-            </div>
-            <div className="text-text-muted text-xs">
-              Provider-specific structured-output transport, no external tool
-            </div>
-          </summary>
-
-          <div className="mt-4">
-            <div className="flex flex-wrap gap-2 mb-3">
-              <button
-                type="button"
-                onClick={() => setPromptFormat("tool")}
-                className={`rounded-full border px-3 py-1.5 text-xs transition-colors ${
-                  promptFormat === "tool"
-                    ? "border-primary bg-primary-soft text-primary"
-                    : "border-border text-text-secondary hover:text-text"
-                }`}
-              >
-                Structured schema
-              </button>
-              <button
-                type="button"
-                onClick={() => setPromptFormat("json")}
-                className={`rounded-full border px-3 py-1.5 text-xs transition-colors ${
-                  promptFormat === "json"
-                    ? "border-primary bg-primary-soft text-primary"
-                    : "border-border text-text-secondary hover:text-text"
-                }`}
-              >
-                JSON schema
-              </button>
-            </div>
-            <pre className="bg-surface rounded-lg border border-border-subtle p-3 text-xs text-text-secondary whitespace-pre-wrap leading-relaxed overflow-x-auto">
-              {promptFormat === "tool" ? activePrompt.tool : activePrompt.json}
-            </pre>
-          </div>
-        </details>
-      )}
 
       <div
         className="mt-6 flex flex-wrap items-center gap-x-4 gap-y-3 animate-fade-up"
@@ -547,13 +453,26 @@ export default function ScenarioExplorer({
                               setSelectedCell({ variable: v, model: m })
                             }
                             aria-pressed={isSelected}
-                            className={`w-full text-right rounded px-1.5 py-0.5 font-[family-name:var(--font-mono)] transition-colors ${
+                            className={`flex w-full items-center justify-end gap-1.5 rounded-md border px-2 py-1 text-right font-[family-name:var(--font-mono)] shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-strong/40 ${
                               isSelected
-                                ? "bg-primary-soft text-primary-strong"
-                                : "hover:bg-surface-soft"
+                                ? "border-primary-strong/50 bg-primary-soft text-primary-strong"
+                                : "border-border-subtle bg-card/60 hover:border-primary-strong/40 hover:bg-surface-soft hover:text-text"
                             }`}
                           >
-                            --
+                            <span>--</span>
+                            <svg
+                              aria-hidden
+                              viewBox="0 0 12 12"
+                              className="h-3 w-3 opacity-60"
+                              fill="none"
+                              stroke="currentColor"
+                              strokeWidth="1.6"
+                              strokeLinecap="round"
+                              strokeLinejoin="round"
+                            >
+                              <circle cx="5" cy="5" r="3" />
+                              <path d="m7.2 7.2 2.3 2.3" />
+                            </svg>
                           </button>
                         </td>
                       );
@@ -576,10 +495,10 @@ export default function ScenarioExplorer({
                             setSelectedCell({ variable: v, model: m })
                           }
                           aria-pressed={isSelected}
-                          className={`w-full text-right rounded px-1.5 py-0.5 font-[family-name:var(--font-mono)] transition-colors ${
+                          className={`flex w-full items-center justify-end gap-1.5 rounded-md border px-2 py-1 text-right font-[family-name:var(--font-mono)] shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-strong/40 ${
                             isSelected
-                              ? "bg-primary-soft ring-1 ring-primary-strong/40"
-                              : "hover:bg-surface-soft"
+                              ? "border-primary-strong/50 bg-primary-soft ring-1 ring-primary-strong/40"
+                              : "border-border-subtle bg-card/60 hover:border-primary-strong/40 hover:bg-surface-soft"
                           }`}
                           style={{
                             color: correct
@@ -587,7 +506,20 @@ export default function ScenarioExplorer({
                               : getPredictionTextColor(predictionError, truth),
                           }}
                         >
-                          {displayPred}
+                          <span>{displayPred}</span>
+                          <svg
+                            aria-hidden
+                            viewBox="0 0 12 12"
+                            className="h-3 w-3 opacity-60"
+                            fill="none"
+                            stroke="currentColor"
+                            strokeWidth="1.6"
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                          >
+                            <circle cx="5" cy="5" r="3" />
+                            <path d="m7.2 7.2 2.3 2.3" />
+                          </svg>
                         </button>
                       </td>
                     );
@@ -598,6 +530,98 @@ export default function ScenarioExplorer({
           </tbody>
         </table>
       </div>
+
+      {totalPredictionRows > 0 && (
+        <div
+          className="card px-5 py-4 mt-6 animate-fade-up"
+          style={{ animationDelay: "340ms" }}
+        >
+          <div className="text-[10px] uppercase tracking-[0.14em] text-text-muted font-medium">
+            Explanation and audit coverage
+          </div>
+          <p className="mt-2 text-sm text-text-secondary leading-relaxed">
+            {explanationRows} of {totalPredictionRows} model-output rows for
+            this household include explanation text returned by the model.{" "}
+            {annotationRows} rows include developer audit notes for incorrect
+            predictions, and {caseAnnotationRows} incorrect rows include
+            case-level notes comparing wrong models on the same
+            household-output target.
+          </p>
+          {Object.keys(failureSources).length > 0 && (
+            <div className="mt-3 flex flex-wrap gap-2">
+              {Object.entries(failureSources)
+                .sort((a, b) => b[1] - a[1])
+                .map(([source, count]) => (
+                  <span
+                    key={source}
+                    className="rounded-full border border-border-subtle bg-surface px-2.5 py-1 text-[11px] text-text-secondary"
+                  >
+                    {formatFailureLabel(source)}: {count}
+                  </span>
+                ))}
+            </div>
+          )}
+        </div>
+      )}
+
+      {activePrompt && (
+        <details
+          className="card px-5 py-4 mt-4 animate-fade-up group"
+          style={{ animationDelay: "360ms" }}
+        >
+          <summary className="cursor-pointer list-none flex flex-wrap items-center justify-between gap-3">
+            <div className="flex items-start gap-2">
+              <span
+                aria-hidden
+                className="mt-0.5 inline-block text-text-muted transition-transform group-open:rotate-90"
+              >
+                ▸
+              </span>
+              <div>
+                <div className="text-[10px] uppercase tracking-[0.14em] text-text-muted font-medium">
+                  Exact prompt
+                </div>
+                <div className="text-text text-sm mt-1">
+                  Full household batch contract for all benchmark outputs
+                </div>
+              </div>
+            </div>
+            <div className="text-text-muted text-xs">
+              Provider-specific structured-output transport, no external tool
+            </div>
+          </summary>
+
+          <div className="mt-4">
+            <div className="flex flex-wrap gap-2 mb-3">
+              <button
+                type="button"
+                onClick={() => setPromptFormat("tool")}
+                className={`rounded-full border px-3 py-1.5 text-xs transition-colors ${
+                  promptFormat === "tool"
+                    ? "border-primary bg-primary-soft text-primary"
+                    : "border-border text-text-secondary hover:text-text"
+                }`}
+              >
+                Structured schema
+              </button>
+              <button
+                type="button"
+                onClick={() => setPromptFormat("json")}
+                className={`rounded-full border px-3 py-1.5 text-xs transition-colors ${
+                  promptFormat === "json"
+                    ? "border-primary bg-primary-soft text-primary"
+                    : "border-border text-text-secondary hover:text-text"
+                }`}
+              >
+                JSON schema
+              </button>
+            </div>
+            <pre className="bg-surface rounded-lg border border-border-subtle p-3 text-xs text-text-secondary whitespace-pre-wrap leading-relaxed overflow-x-auto">
+              {promptFormat === "tool" ? activePrompt.tool : activePrompt.json}
+            </pre>
+          </div>
+        </details>
+      )}
 
       <DetailDialog
         ref={dialogRef}

--- a/app/src/components/ScenarioExplorer.tsx
+++ b/app/src/components/ScenarioExplorer.tsx
@@ -1,4 +1,10 @@
-import React, { useEffect, useMemo, useRef, useState } from "react";
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import {
   getVariableLabel,
   isBinaryVariable,
@@ -16,7 +22,9 @@ import {
   isFrontierModel,
   type ProviderKey,
 } from "../modelMeta";
+import { programIsActive, type ProgramOption } from "../lib/programFilters";
 import ProviderMark from "./ProviderMark";
+import ProgramFilterDropdown from "./ProgramFilterDropdown";
 
 function formatBoolean(value: number): string {
   return value === 1 ? "Yes" : "No";
@@ -85,8 +93,20 @@ function pickRandomScenario(
 
 export default function ScenarioExplorer({
   data,
+  programOptions,
+  activeProgramIds,
+  activeProgramSummary,
+  onResetPrograms,
+  onToggleProgram,
+  onSelectOnlyProgram,
 }: {
   data: BenchData;
+  programOptions: ProgramOption[];
+  activeProgramIds: Set<string>;
+  activeProgramSummary: string;
+  onResetPrograms: () => void;
+  onToggleProgram: (variable: string) => void;
+  onSelectOnlyProgram: (variable: string) => void;
 }) {
   const country = data.country;
   const [promptFormat, setPromptFormat] = useState<"tool" | "json">("tool");
@@ -112,7 +132,23 @@ export default function ScenarioExplorer({
     [data, resolvedScenarioId],
   );
 
-  const variables = useMemo(() => Object.keys(predictions).sort(), [predictions]);
+  const isProgramActive = useCallback(
+    (variable: string) => programIsActive(activeProgramIds, variable),
+    [activeProgramIds],
+  );
+
+  const variables = useMemo(
+    () => Object.keys(predictions).filter(isProgramActive).sort(),
+    [isProgramActive, predictions],
+  );
+
+  const filteredPredictions = useMemo(() => {
+    const out: Record<string, Record<string, ScenarioPrediction>> = {};
+    for (const variable of variables) {
+      out[variable] = predictions[variable] ?? {};
+    }
+    return out;
+  }, [predictions, variables]);
 
   // Frontier-only narrows to one flagship per provider; provider chips
   // multi-select. The scenario explorer table is wide (one column per model),
@@ -124,11 +160,11 @@ export default function ScenarioExplorer({
 
   const allModels = useMemo(() => {
     const unique = new Set<string>();
-    for (const varData of Object.values(predictions)) {
+    for (const varData of Object.values(filteredPredictions)) {
       for (const m of Object.keys(varData)) unique.add(m);
     }
     return MODEL_ORDER.filter((m) => unique.has(m));
-  }, [predictions]);
+  }, [filteredPredictions]);
 
   const models = useMemo(() => {
     return allModels.filter((m) => {
@@ -149,7 +185,9 @@ export default function ScenarioExplorer({
   } | null>(null);
 
   const selectedCell =
-    manualSelection && manualSelection.scenarioId === resolvedScenarioId
+    manualSelection &&
+    manualSelection.scenarioId === resolvedScenarioId &&
+    variables.includes(manualSelection.cell.variable)
       ? manualSelection.cell
       : null;
 
@@ -181,19 +219,21 @@ export default function ScenarioExplorer({
   const geographyLabel = country === "uk" ? "Region" : "State";
   const hasFilingStatus = !!scenario.filingStatus;
   const currencySymbol = country === "uk" ? "£" : "$";
-  const explanationRows = Object.values(predictions).reduce(
+  const explanationRows = Object.values(filteredPredictions).reduce(
     (sum, modelMap) =>
       sum +
       Object.values(modelMap).filter((entry) => !!entry.explanation).length,
     0,
   );
-  const annotationRows = Object.values(predictions).reduce(
+  const annotationRows = Object.values(filteredPredictions).reduce(
     (sum, modelMap) =>
       sum +
       Object.values(modelMap).filter((entry) => !!entry.annotation).length,
     0,
   );
-  const failureSources = Object.values(predictions).reduce<Record<string, number>>(
+  const failureSources = Object.values(filteredPredictions).reduce<
+    Record<string, number>
+  >(
     (counts, modelMap) => {
       for (const entry of Object.values(modelMap)) {
         if (!entry.failureSource) continue;
@@ -203,13 +243,13 @@ export default function ScenarioExplorer({
     },
     {},
   );
-  const caseAnnotationRows = Object.values(predictions).reduce(
+  const caseAnnotationRows = Object.values(filteredPredictions).reduce(
     (sum, modelMap) =>
       sum +
       Object.values(modelMap).filter((entry) => !!entry.caseAnnotation).length,
     0,
   );
-  const totalPredictionRows = Object.values(predictions).reduce(
+  const totalPredictionRows = Object.values(filteredPredictions).reduce(
     (sum, modelMap) => sum + Object.keys(modelMap).length,
     0,
   );
@@ -323,6 +363,17 @@ export default function ScenarioExplorer({
         className="mt-6 flex flex-wrap items-center gap-x-4 gap-y-3 animate-fade-up"
         style={{ animationDelay: "300ms" }}
       >
+        <div className="basis-full">
+          <ProgramFilterDropdown
+            options={programOptions}
+            activeProgramIds={activeProgramIds}
+            summary={activeProgramSummary}
+            description="Shared with model scoring and the program breakdown. Scenario rows show only selected outputs; the model column filter stays local to this table."
+            onReset={onResetPrograms}
+            onToggle={onToggleProgram}
+            onSelectOnly={onSelectOnlyProgram}
+          />
+        </div>
         <div className="flex flex-wrap items-center gap-2">
           <span
             id="scenarios-filter-label"
@@ -626,7 +677,7 @@ export default function ScenarioExplorer({
       <DetailDialog
         ref={dialogRef}
         selectedCell={selectedCell}
-        predictions={predictions}
+        predictions={filteredPredictions}
         country={country}
         currencySymbol={currencySymbol}
         onClose={closeModal}

--- a/app/src/components/SiteHeader.tsx
+++ b/app/src/components/SiteHeader.tsx
@@ -15,6 +15,11 @@ export type HeaderActionLink = {
   type?: "internal" | "external";
 };
 
+const HEADER_BACKGROUND_REVEAL_START = 0;
+const HEADER_BACKGROUND_REVEAL_DISTANCE = 160;
+const COMPACT_HEADER_REVEAL_START = 280;
+const COMPACT_HEADER_REVEAL_DISTANCE = 72;
+
 function ViewSelector({
   selectedView,
   onSelect,
@@ -49,9 +54,9 @@ function ViewSelector({
   );
 }
 
-function getScrollProgress(threshold: number) {
+function getScrollProgress(start: number, distance: number) {
   if (typeof window === "undefined") return 0;
-  return Math.min(1, Math.max(0, window.scrollY / threshold));
+  return Math.min(1, Math.max(0, (window.scrollY - start) / distance));
 }
 
 function prefersReducedMotion(): boolean {
@@ -61,33 +66,54 @@ function prefersReducedMotion(): boolean {
   return window.matchMedia("(prefers-reduced-motion: reduce)").matches;
 }
 
-function useScrollProgress(threshold: number, enabled: boolean) {
+function useScrollProgress(start: number, distance: number, enabled: boolean) {
   const [progress, setProgress] = useState(() =>
-    enabled ? getScrollProgress(threshold) : 0,
+    enabled ? getScrollProgress(start, distance) : 0,
   );
   const rafRef = useRef(0);
 
   useEffect(() => {
     if (!enabled) return;
     if (prefersReducedMotion()) {
-      const snap = () => setProgress(getScrollProgress(threshold) > 0.5 ? 1 : 0);
+      const snap = () =>
+        setProgress(getScrollProgress(start, distance) > 0.5 ? 1 : 0);
       snap();
+      const timeout = window.setTimeout(snap, 0);
       window.addEventListener("scroll", snap, { passive: true });
-      return () => window.removeEventListener("scroll", snap);
+      window.addEventListener("resize", snap);
+      window.addEventListener("hashchange", snap);
+      window.addEventListener("load", snap);
+      return () => {
+        window.clearTimeout(timeout);
+        window.removeEventListener("scroll", snap);
+        window.removeEventListener("resize", snap);
+        window.removeEventListener("hashchange", snap);
+        window.removeEventListener("load", snap);
+      };
     }
     const onScroll = () => {
       cancelAnimationFrame(rafRef.current);
       rafRef.current = requestAnimationFrame(() => {
-        setProgress(getScrollProgress(threshold));
+        setProgress(getScrollProgress(start, distance));
       });
     };
     onScroll();
+    const settleTimeout = window.setTimeout(onScroll, 0);
+    const hashScrollTimeout = window.setTimeout(onScroll, 120);
     window.addEventListener("scroll", onScroll, { passive: true });
+    window.addEventListener("resize", onScroll);
+    window.addEventListener("hashchange", onScroll);
+    window.addEventListener("load", onScroll);
     return () => {
+      window.clearTimeout(settleTimeout);
+      window.clearTimeout(hashScrollTimeout);
       window.removeEventListener("scroll", onScroll);
+      window.removeEventListener("resize", onScroll);
+      window.removeEventListener("hashchange", onScroll);
+      window.removeEventListener("load", onScroll);
       cancelAnimationFrame(rafRef.current);
     };
-  }, [threshold, enabled]);
+  }, [start, distance, enabled]);
 
   return enabled ? progress : 0;
 }
@@ -124,12 +150,22 @@ export default function SiteHeader({
   expandedContent,
   alwaysExpanded = false,
 }: SiteHeaderProps) {
-  // Background and content opacity are scroll-driven so the sticky bar reveals
-  // itself as the in-flow hero scrolls away. These properties don't affect
-  // layout, so they can't trigger the scroll-position feedback loop.
-  const progress = useScrollProgress(160, !alwaysExpanded);
-  const bgOpacity = alwaysExpanded ? 1 : progress;
-  const contentOpacity = alwaysExpanded ? 1 : progress;
+  // Background and compact content opacity are scroll-driven, but staggered:
+  // the background covers text moving under the sticky bar, while the compact
+  // brand/nav wait until the hero intro has cleared. These properties don't
+  // affect layout, so they can't trigger the scroll-position feedback loop.
+  const backgroundProgress = useScrollProgress(
+    HEADER_BACKGROUND_REVEAL_START,
+    HEADER_BACKGROUND_REVEAL_DISTANCE,
+    !alwaysExpanded,
+  );
+  const compactContentProgress = useScrollProgress(
+    COMPACT_HEADER_REVEAL_START,
+    COMPACT_HEADER_REVEAL_DISTANCE,
+    !alwaysExpanded,
+  );
+  const bgOpacity = alwaysExpanded ? 1 : backgroundProgress;
+  const contentOpacity = alwaysExpanded ? 1 : compactContentProgress;
   const contentVisible = alwaysExpanded || contentOpacity > 0.05;
 
   const showViewSelector =
@@ -138,7 +174,7 @@ export default function SiteHeader({
   return (
     <header className="sticky top-0 z-40">
       <div
-        className="absolute inset-0 border-b backdrop-blur-md"
+        className="pointer-events-none absolute inset-0 border-b backdrop-blur-md"
         style={{
           opacity: bgOpacity,
           backgroundColor: `color-mix(in srgb, var(--color-bg) ${Math.round(
@@ -164,11 +200,14 @@ export default function SiteHeader({
         >
           <Link
             href="/"
-            className="shrink-0 transition-opacity hover:opacity-80"
+            className="shrink-0 hover:opacity-80"
             style={
               alwaysExpanded
                 ? undefined
-                : { opacity: contentOpacity, pointerEvents: contentVisible ? "auto" : "none" }
+                : {
+                    opacity: contentOpacity,
+                    pointerEvents: contentVisible ? "auto" : "none",
+                  }
             }
             tabIndex={alwaysExpanded || contentVisible ? 0 : -1}
             aria-hidden={!alwaysExpanded && !contentVisible ? true : undefined}
@@ -184,7 +223,7 @@ export default function SiteHeader({
 
           {navItems.length > 0 && (
             <div
-              className="flex items-center transition-opacity"
+              className="flex items-center"
               style={{
                 opacity: contentOpacity,
                 pointerEvents: contentVisible ? "auto" : "none",

--- a/app/src/components/SiteHeader.tsx
+++ b/app/src/components/SiteHeader.tsx
@@ -66,6 +66,23 @@ function prefersReducedMotion(): boolean {
   return window.matchMedia("(prefers-reduced-motion: reduce)").matches;
 }
 
+function useMobileHeader() {
+  const [isMobileHeader, setIsMobileHeader] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === "undefined" || typeof window.matchMedia !== "function") {
+      return;
+    }
+    const media = window.matchMedia("(max-width: 767px)");
+    const update = () => setIsMobileHeader(media.matches);
+    update();
+    media.addEventListener("change", update);
+    return () => media.removeEventListener("change", update);
+  }, []);
+
+  return isMobileHeader;
+}
+
 function useScrollProgress(start: number, distance: number, enabled: boolean) {
   const [progress, setProgress] = useState(() =>
     enabled ? getScrollProgress(start, distance) : 0,
@@ -154,6 +171,7 @@ export default function SiteHeader({
   // the background covers text moving under the sticky bar, while the compact
   // brand/nav wait until the hero intro has cleared. These properties don't
   // affect layout, so they can't trigger the scroll-position feedback loop.
+  const isMobileHeader = useMobileHeader();
   const backgroundProgress = useScrollProgress(
     HEADER_BACKGROUND_REVEAL_START,
     HEADER_BACKGROUND_REVEAL_DISTANCE,
@@ -164,15 +182,17 @@ export default function SiteHeader({
     COMPACT_HEADER_REVEAL_DISTANCE,
     !alwaysExpanded,
   );
-  const bgOpacity = alwaysExpanded ? 1 : backgroundProgress;
-  const contentOpacity = alwaysExpanded ? 1 : compactContentProgress;
+  const bgOpacity = alwaysExpanded || isMobileHeader ? 1 : backgroundProgress;
+  const contentOpacity =
+    alwaysExpanded || isMobileHeader ? 1 : compactContentProgress;
   const contentVisible = alwaysExpanded || contentOpacity > 0.05;
 
   const showViewSelector =
     availableViews && availableViews.length > 0 && selectedView && onSelectView;
+  const headerPositionClass = alwaysExpanded ? "relative z-40" : "sticky top-0 z-40";
 
   return (
-    <header className="sticky top-0 z-40">
+    <header className={headerPositionClass}>
       <div
         className="pointer-events-none absolute inset-0 border-b backdrop-blur-md"
         style={{
@@ -194,13 +214,13 @@ export default function SiteHeader({
 
       <div className="relative max-w-7xl mx-auto px-4 sm:px-6">
         <div
-          className={`flex items-center gap-3 ${
-            alwaysExpanded ? "pt-10 pb-4" : "py-3"
+          className={`flex flex-wrap items-center gap-2 sm:gap-3 ${
+            alwaysExpanded ? "pt-8 pb-4 sm:pt-10" : "py-2 sm:py-3"
           }`}
         >
           <Link
             href="/"
-            className="shrink-0 hover:opacity-80"
+            className="order-1 shrink-0 hover:opacity-80 sm:order-none"
             style={
               alwaysExpanded
                 ? undefined
@@ -223,14 +243,14 @@ export default function SiteHeader({
 
           {navItems.length > 0 && (
             <div
-              className="flex items-center"
+              className="order-last flex w-full min-w-0 items-center overflow-x-auto sm:order-none sm:w-auto sm:overflow-visible"
               style={{
                 opacity: contentOpacity,
                 pointerEvents: contentVisible ? "auto" : "none",
               }}
               aria-hidden={!contentVisible ? true : undefined}
             >
-              <div className="h-4 w-px bg-border shrink-0 mx-2" />
+              <div className="mx-2 hidden h-4 w-px shrink-0 bg-border sm:block" />
               <div className="flex min-w-max gap-0.5">
                 {navItems.map((item) => (
                   <a
@@ -238,7 +258,7 @@ export default function SiteHeader({
                     href={`#${item.id}`}
                     tabIndex={contentVisible ? 0 : -1}
                     aria-current={activeNav === item.id ? "true" : undefined}
-                    className={`px-2.5 py-2 text-[11px] font-medium tracking-wider uppercase border-b-2 sm:px-3 ${
+                    className={`border-b-2 px-2 py-2 text-[10px] font-medium uppercase tracking-[0.08em] sm:px-3 sm:text-[11px] sm:tracking-wider ${
                       activeNav === item.id
                         ? "border-primary-strong text-primary-strong"
                         : "border-transparent text-text-secondary hover:text-text"
@@ -251,18 +271,20 @@ export default function SiteHeader({
             </div>
           )}
 
-          <div className="flex-1" />
+          <div className="order-2 min-w-2 flex-1 sm:order-none" />
 
           {showViewSelector && (
-            <ViewSelector
-              selectedView={selectedView}
-              onSelect={onSelectView}
-              views={availableViews}
-            />
+            <div className="order-4 max-w-full sm:order-none">
+              <ViewSelector
+                selectedView={selectedView}
+                onSelect={onSelectView}
+                views={availableViews}
+              />
+            </div>
           )}
 
           {actionLink && (
-            <div>
+            <div className="order-3 shrink-0 sm:order-none">
               {actionLink.type === "external" ? (
                 <a
                   href={actionLink.href}
@@ -283,7 +305,7 @@ export default function SiteHeader({
 
           <a
             href="https://policyengine.org"
-            className="inline-flex shrink-0 items-center gap-1.5 rounded-full border border-border bg-card px-3 py-1.5 text-[11px] font-medium uppercase tracking-wider text-text-secondary transition-colors hover:border-primary-strong/40 hover:text-primary-strong"
+            className="order-5 hidden shrink-0 items-center gap-1.5 rounded-full border border-border bg-card px-3 py-1.5 text-[11px] font-medium uppercase tracking-wider text-text-secondary transition-colors hover:border-primary-strong/40 hover:text-primary-strong md:inline-flex"
           >
             <span>by</span>
             <img

--- a/app/src/components/SiteHeader.tsx
+++ b/app/src/components/SiteHeader.tsx
@@ -24,10 +24,12 @@ function ViewSelector({
   selectedView,
   onSelect,
   views,
+  viewHrefs,
 }: {
   selectedView: ViewKey;
   onSelect: (view: ViewKey) => void;
   views: ViewKey[];
+  viewHrefs?: Partial<Record<ViewKey, string>>;
 }) {
   return (
     <div
@@ -35,21 +37,40 @@ function ViewSelector({
       aria-label="Country view"
       className="inline-flex max-w-full items-center gap-1 rounded-full border border-border bg-bg/80 p-1"
     >
-      {views.map((view) => (
-        <button
-          key={view}
-          type="button"
-          onClick={() => onSelect(view)}
-          aria-pressed={selectedView === view}
-          className={`rounded-full text-[11px] px-3 py-1.5 font-medium transition-colors ${
+      {views.map((view) => {
+        const href = viewHrefs?.[view];
+        const className = `rounded-full text-[11px] px-3 py-1.5 font-medium transition-colors ${
             selectedView === view
               ? "bg-primary-strong text-white"
               : "text-text-secondary hover:text-text"
-          }`}
-        >
-          {VIEW_LABELS[view]}
-        </button>
-      ))}
+          }`;
+
+        if (href) {
+          return (
+            <Link
+              key={view}
+              href={href}
+              onClick={() => onSelect(view)}
+              aria-current={selectedView === view ? "page" : undefined}
+              className={className}
+            >
+              {VIEW_LABELS[view]}
+            </Link>
+          );
+        }
+
+        return (
+          <button
+            key={view}
+            type="button"
+            onClick={() => onSelect(view)}
+            aria-pressed={selectedView === view}
+            className={className}
+          >
+            {VIEW_LABELS[view]}
+          </button>
+        );
+      })}
     </div>
   );
 }
@@ -141,6 +162,7 @@ export type SiteHeaderProps = {
   selectedView?: ViewKey;
   onSelectView?: (view: ViewKey) => void;
   availableViews?: ViewKey[];
+  viewHrefs?: Partial<Record<ViewKey, string>>;
   actionLink?: HeaderActionLink;
   /**
    * Optional expanded content shown inside the sticky header. Use only with
@@ -163,6 +185,7 @@ export default function SiteHeader({
   selectedView,
   onSelectView,
   availableViews,
+  viewHrefs,
   actionLink,
   expandedContent,
   alwaysExpanded = false,
@@ -279,6 +302,7 @@ export default function SiteHeader({
                 selectedView={selectedView}
                 onSelect={onSelectView}
                 views={availableViews}
+                viewHrefs={viewHrefs}
               />
             </div>
           )}

--- a/app/src/components/SiteHeader.tsx
+++ b/app/src/components/SiteHeader.tsx
@@ -208,7 +208,7 @@ export default function SiteHeader({
 
       {alwaysExpanded && (
         <div
-          className="absolute inset-x-0 top-0 h-[280px] bg-[radial-gradient(circle_at_top,_color-mix(in_srgb,var(--color-primary)_13%,transparent),transparent_58%)] pointer-events-none"
+          className="absolute inset-x-0 top-0 h-[280px] bg-[radial-gradient(ellipse_70%_100%_at_top,_color-mix(in_srgb,var(--color-primary)_13%,transparent)_0%,transparent_70%)] pointer-events-none"
         />
       )}
 

--- a/app/src/lib/dashboardFilter.ts
+++ b/app/src/lib/dashboardFilter.ts
@@ -1,0 +1,272 @@
+import type {
+  BenchData,
+  DashboardBundle,
+  GlobalWeightsByView,
+  HeatmapEntry,
+  ModelStat,
+  ScenarioPredictionsByVariable,
+  WeightingKey,
+} from "../types";
+import {
+  metricTypeForVariable,
+  outputGroupForVariable,
+  scorePrediction,
+} from "./scoring";
+
+const EXCLUDED_OUTPUTS = new Set(["premium_tax_credit"]);
+const WEIGHTING_KEYS: WeightingKey[] = ["household", "aggregate", "equal"];
+
+function isExcludedOutput(variable: string): boolean {
+  return EXCLUDED_OUTPUTS.has(outputGroupForVariable(variable));
+}
+
+function scrubPrompt(text?: string): string | undefined {
+  return text
+    ?.replace(/; exclude the ACA Premium Tax Credit/g, "")
+    .replace(
+      /\n- premium_tax_credit:[\s\S]*?(?=\n- [a-z0-9_]+:|\n\nUse the `submit_outputs`|$)/g,
+      "",
+    );
+}
+
+function normalizeWeights(weights: Record<string, number>): Record<string, number> {
+  const entries = Object.entries(weights).filter(
+    ([variable]) => !isExcludedOutput(variable),
+  );
+  const total = entries.reduce((sum, [, weight]) => sum + weight, 0);
+  if (total <= 0) return Object.fromEntries(entries);
+  return Object.fromEntries(
+    entries.map(([variable, weight]) => [variable, weight / total]),
+  );
+}
+
+function filterWeights(weights?: GlobalWeightsByView): GlobalWeightsByView | undefined {
+  if (!weights) return undefined;
+  return Object.fromEntries(
+    WEIGHTING_KEYS.map((key) => [key, normalizeWeights(weights[key] ?? {})]),
+  ) as GlobalWeightsByView;
+}
+
+function groupWeights(weights: Record<string, number>): Record<string, number> {
+  const grouped: Record<string, number> = {};
+  for (const [variable, weight] of Object.entries(weights)) {
+    const group = outputGroupForVariable(variable);
+    grouped[group] = (grouped[group] ?? 0) + weight;
+  }
+  return grouped;
+}
+
+function metricHits(
+  variable: string,
+  truth: number,
+  prediction: number | null | undefined,
+  country: BenchData["country"],
+) {
+  const parsed =
+    prediction !== null && prediction !== undefined && !Number.isNaN(prediction);
+  if (!parsed) {
+    return { parsed: false, exact: 0, within1pct: 0, within5pct: 0, within10pct: 0 };
+  }
+  if (metricTypeForVariable(variable, country) === "binary") {
+    const exact = Math.round(prediction) === Math.round(truth) ? 1 : 0;
+    return { parsed, exact, within1pct: exact, within5pct: exact, within10pct: exact };
+  }
+  const absError = Math.abs(prediction - truth);
+  const exact = absError <= 1 ? 1 : 0;
+  const within = (tolerance: number) =>
+    truth === 0 ? exact : absError / Math.abs(truth) <= tolerance ? 1 : 0;
+  return {
+    parsed,
+    exact,
+    within1pct: within(0.01),
+    within5pct: within(0.05),
+    within10pct: within(0.1),
+  };
+}
+
+function weightedHeatmapScore(
+  heatmap: HeatmapEntry[],
+  model: string,
+  weights: Record<string, number>,
+): number | undefined {
+  const groupedWeights = groupWeights(weights);
+  let numerator = 0;
+  let denominator = 0;
+  for (const entry of heatmap) {
+    if (entry.condition !== "no_tools" || entry.model !== model) continue;
+    const weight = groupedWeights[entry.variable];
+    if (weight === undefined) continue;
+    numerator += weight * (entry.score / 100);
+    denominator += weight;
+  }
+  return denominator > 0 ? (numerator / denominator) * 100 : undefined;
+}
+
+function recomputeModelStats(
+  payload: BenchData,
+  scenarioPredictions: Record<string, ScenarioPredictionsByVariable>,
+  heatmap: HeatmapEntry[],
+  weights?: GlobalWeightsByView,
+): ModelStat[] {
+  return payload.modelStats.map((stat) => {
+    if (stat.condition !== "no_tools") return stat;
+
+    let n = 0;
+    let nParsed = 0;
+    let exact = 0;
+    let within1pct = 0;
+    let within5pct = 0;
+    let within10pct = 0;
+    let amountN = 0;
+    let amountScore = 0;
+    let participationN = 0;
+    let participationScore = 0;
+    let maeN = 0;
+    let mae = 0;
+
+    for (const variableMap of Object.values(scenarioPredictions)) {
+      for (const [variable, modelMap] of Object.entries(variableMap)) {
+        const row = modelMap[stat.model];
+        if (!row) continue;
+        n += 1;
+        const hits = metricHits(
+          variable,
+          row.groundTruth,
+          row.prediction,
+          payload.country,
+        );
+        if (hits.parsed) {
+          nParsed += 1;
+          mae += Math.abs((row.prediction ?? 0) - row.groundTruth);
+          maeN += 1;
+        }
+        exact += hits.exact;
+        within1pct += hits.within1pct;
+        within5pct += hits.within5pct;
+        within10pct += hits.within10pct;
+
+        if (metricTypeForVariable(variable, payload.country) === "binary") {
+          participationN += 1;
+          participationScore += hits.exact;
+        } else {
+          amountN += 1;
+          amountScore += scorePrediction(
+            variable,
+            payload.country,
+            row.groundTruth,
+            row.prediction,
+          );
+        }
+      }
+    }
+
+    const modelHeatmap = heatmap.filter(
+      (entry) => entry.condition === "no_tools" && entry.model === stat.model,
+    );
+    const outputGroupScore =
+      modelHeatmap.length > 0
+        ? modelHeatmap.reduce((sum, entry) => sum + entry.score, 0) /
+          modelHeatmap.length
+        : stat.outputGroupScore;
+    const boundedScore =
+      weights?.household && weightedHeatmapScore(heatmap, stat.model, weights.household);
+    const aggregateScore =
+      weights?.aggregate && weightedHeatmapScore(heatmap, stat.model, weights.aggregate);
+    const equalScore =
+      weights?.equal && weightedHeatmapScore(heatmap, stat.model, weights.equal);
+
+    return {
+      ...stat,
+      score: boundedScore ?? stat.score,
+      outputGroupScore,
+      exact: n > 0 ? (exact / n) * 100 : stat.exact,
+      within1pct: n > 0 ? (within1pct / n) * 100 : stat.within1pct,
+      within5pct: n > 0 ? (within5pct / n) * 100 : stat.within5pct,
+      within10pct: n > 0 ? (within10pct / n) * 100 : stat.within10pct,
+      n,
+      nParsed,
+      coverage: n > 0 ? (nParsed / n) * 100 : stat.coverage,
+      mae: maeN > 0 ? mae / maeN : stat.mae,
+      amountAccuracy:
+        amountN > 0 ? (amountScore / amountN) * 100 : stat.amountAccuracy,
+      participationAccuracy:
+        participationN > 0
+          ? (participationScore / participationN) * 100
+          : stat.participationAccuracy,
+      boundedScore: boundedScore ?? stat.boundedScore,
+      aggregateScore: aggregateScore ?? stat.aggregateScore,
+      equalScore: equalScore ?? stat.equalScore,
+    };
+  });
+}
+
+function filterCountryPayload(payload: BenchData): BenchData {
+  const hasExcludedOutput =
+    payload.programStats.some((program) => isExcludedOutput(program.variable)) ||
+    payload.heatmap.some((entry) => isExcludedOutput(entry.variable)) ||
+    Object.values(payload.scenarioPredictions).some((variableMap) =>
+      Object.keys(variableMap).some(isExcludedOutput),
+    );
+  if (!hasExcludedOutput) return payload;
+
+  const scenarios = Object.fromEntries(
+    Object.entries(payload.scenarios).map(([scenarioId, scenario]) => [
+      scenarioId,
+      {
+        ...scenario,
+        prompt: scenario.prompt
+          ? {
+              tool: scrubPrompt(scenario.prompt.tool),
+              json: scrubPrompt(scenario.prompt.json),
+            }
+          : undefined,
+      },
+    ]),
+  );
+  const scenarioPredictions = Object.fromEntries(
+    Object.entries(payload.scenarioPredictions).map(([scenarioId, variableMap]) => [
+      scenarioId,
+      Object.fromEntries(
+        Object.entries(variableMap).filter(
+          ([variable]) => !isExcludedOutput(variable),
+        ),
+      ),
+    ]),
+  );
+  const heatmap = payload.heatmap.filter(
+    (entry) => !isExcludedOutput(entry.variable),
+  );
+  const weights = filterWeights(payload.globalWeights);
+
+  return {
+    ...payload,
+    scenarios,
+    scenarioPredictions,
+    programStats: payload.programStats.filter(
+      (program) => !isExcludedOutput(program.variable),
+    ),
+    heatmap,
+    globalWeights: weights,
+    failureModes: {
+      ...payload.failureModes,
+      programs: payload.failureModes.programs.filter(
+        (program) => !isExcludedOutput(program.variable),
+      ),
+    },
+    modelStats: recomputeModelStats(payload, scenarioPredictions, heatmap, weights),
+  };
+}
+
+export function filterExcludedOutputs(
+  dashboard: DashboardBundle,
+): DashboardBundle {
+  return {
+    ...dashboard,
+    countries: Object.fromEntries(
+      Object.entries(dashboard.countries).map(([country, payload]) => [
+        country,
+        payload ? filterCountryPayload(payload) : payload,
+      ]),
+    ),
+  };
+}

--- a/app/src/lib/programFilters.ts
+++ b/app/src/lib/programFilters.ts
@@ -1,0 +1,132 @@
+import { getVariableLabel, type BenchData } from "../types";
+import { outputGroupForVariable } from "./scoring";
+
+export type ProgramOption = {
+  variable: string;
+  label: string;
+};
+
+export type ProgramRate = {
+  variable: string;
+  value: number | undefined;
+};
+
+export function buildProgramOptions(data: BenchData): ProgramOption[] {
+  const variables = new Set<string>();
+  for (const entry of data.heatmap) {
+    if (entry.condition === "no_tools") {
+      variables.add(outputGroupForVariable(entry.variable));
+    }
+  }
+  return Array.from(variables)
+    .map((variable) => ({
+      variable,
+      label: getVariableLabel(variable, data.country),
+    }))
+    .sort((a, b) => a.label.localeCompare(b.label));
+}
+
+export function resolveActiveProgramIds(
+  programOptionIds: readonly string[],
+  selectedPrograms: Set<string>,
+): Set<string> {
+  const all = new Set(programOptionIds);
+  if (selectedPrograms.size === 0) return all;
+  const active = new Set(
+    [...selectedPrograms]
+      .map(outputGroupForVariable)
+      .filter((variable) => all.has(variable)),
+  );
+  return active.size > 0 ? active : all;
+}
+
+export function toggleProgramSelection(
+  programOptionIds: readonly string[],
+  selectedPrograms: Set<string>,
+  variable: string,
+): Set<string> {
+  const allowed = new Set(programOptionIds);
+  const normalized = new Set(
+    [...selectedPrograms]
+      .map(outputGroupForVariable)
+      .filter((value) => allowed.has(value)),
+  );
+  const next =
+    selectedPrograms.size === 0 || normalized.size === 0
+      ? new Set(programOptionIds)
+      : normalized;
+  const groupedVariable = outputGroupForVariable(variable);
+
+  if (next.has(groupedVariable)) {
+    if (next.size === 1) return next;
+    next.delete(groupedVariable);
+  } else {
+    next.add(groupedVariable);
+  }
+
+  return next.size === programOptionIds.length ? new Set() : next;
+}
+
+export function selectOnlyProgram(variable: string): Set<string> {
+  return new Set([outputGroupForVariable(variable)]);
+}
+
+export function programIsActive(
+  activeProgramIds: Set<string>,
+  variable: string,
+): boolean {
+  return activeProgramIds.has(outputGroupForVariable(variable));
+}
+
+export function groupWeights(
+  weights: Record<string, number>,
+): Record<string, number> {
+  const grouped: Record<string, number> = {};
+  for (const [variable, weight] of Object.entries(weights)) {
+    const group = outputGroupForVariable(variable);
+    grouped[group] = (grouped[group] ?? 0) + weight;
+  }
+  return grouped;
+}
+
+export function weightForProgram(
+  weights: Record<string, number>,
+  variable: string,
+): number | undefined {
+  return groupWeights(weights)[outputGroupForVariable(variable)];
+}
+
+function groupRates(rates: Iterable<ProgramRate>): ProgramRate[] {
+  const grouped = new Map<string, { sum: number; n: number }>();
+  for (const { variable, value } of rates) {
+    if (value === undefined) continue;
+    const group = outputGroupForVariable(variable);
+    const acc = grouped.get(group) ?? { sum: 0, n: 0 };
+    acc.sum += value;
+    acc.n += 1;
+    grouped.set(group, acc);
+  }
+  return [...grouped.entries()].map(([variable, { sum, n }]) => ({
+    variable,
+    value: sum / n,
+  }));
+}
+
+export function weightedProgramScore(
+  rates: Iterable<ProgramRate>,
+  weights: Record<string, number>,
+): number | undefined {
+  const groupedWeights = groupWeights(weights);
+  let numerator = 0;
+  let denominator = 0;
+
+  for (const { variable, value } of groupRates(rates)) {
+    if (value === undefined) continue;
+    const weight = groupedWeights[variable];
+    if (weight === undefined) continue;
+    numerator += weight * (value / 100);
+    denominator += weight;
+  }
+
+  return denominator > 0 ? (numerator / denominator) * 100 : undefined;
+}

--- a/app/src/types.ts
+++ b/app/src/types.ts
@@ -27,7 +27,6 @@ const US_VARIABLE_LABELS: Record<string, string> = {
   snap: "SNAP",
   ssi: "SSI",
   tanf: "TANF",
-  premium_tax_credit: "ACA Premium Tax Credit",
   free_school_meals_eligible: "Free school meals eligibility",
   reduced_price_school_meals_eligible:
     "Reduced-price school meals eligibility",
@@ -64,7 +63,6 @@ const US_VARIABLE_CATEGORIES: Record<string, string> = {
   snap: "Benefits",
   ssi: "Benefits",
   tanf: "Benefits",
-  premium_tax_credit: "Health",
   free_school_meals_eligible: "Coverage",
   reduced_price_school_meals_eligible: "Coverage",
   person_wic_eligible: "Coverage",

--- a/app/src/variableExplainers.ts
+++ b/app/src/variableExplainers.ts
@@ -19,15 +19,7 @@ const US_EXPLAINERS: Record<string, VariableExplainer> = {
       "This target captures the refundable federal credit side of the income-tax calculation.",
     bullets: [
       "It includes EITC and refundable portions of credits such as refundable CTC when applicable.",
-      "It excludes the ACA Premium Tax Credit, which is outside the benchmark federal income-tax target.",
-    ],
-  },
-  premium_tax_credit: {
-    summary:
-      "This target captures ACA Marketplace premium assistance as a health-related resource, separate from federal income-tax credits.",
-    bullets: [
-      "It depends on Marketplace eligibility, disqualifying health coverage such as affordable employer coverage, ACA MAGI, and the local second-lowest-cost silver plan premium.",
-      "Marketplace plan facts are phrased as selected-plan information a household might know, while the local benchmark premium usually still has to be estimated.",
+      "It keeps refundable income-tax credits separate from the nonrefundable-credit target.",
     ],
   },
   snap: {

--- a/app/tests/programFilters.test.ts
+++ b/app/tests/programFilters.test.ts
@@ -1,0 +1,81 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  resolveActiveProgramIds,
+  selectOnlyProgram,
+  toggleProgramSelection,
+  weightForProgram,
+  weightedProgramScore,
+} from "../src/lib/programFilters";
+
+function assertClose(actual: number | undefined, expected: number): void {
+  assert.notEqual(actual, undefined);
+  assert.ok(Math.abs(actual - expected) < 1e-9);
+}
+
+test("weightedProgramScore rescales weights over selected programs", () => {
+  const weights = {
+    federal_income_tax_before_refundable_credits: 0.9,
+    snap: 0.1,
+  };
+
+  assertClose(
+    weightedProgramScore(
+      [
+        { variable: "federal_income_tax_before_refundable_credits", value: 80 },
+        { variable: "snap", value: 20 },
+      ],
+      weights,
+    ),
+    74,
+  );
+  assertClose(
+    weightedProgramScore(
+      [{ variable: "federal_income_tax_before_refundable_credits", value: 80 }],
+      weights,
+    ),
+    80,
+  );
+});
+
+test("weightedProgramScore groups person-level eligibility outputs", () => {
+  const weights = {
+    person_wic_eligible: 0.4,
+    snap: 0.6,
+  };
+
+  assert.equal(weightForProgram(weights, "head_wic_eligible"), 0.4);
+  assertClose(
+    weightedProgramScore(
+      [
+        { variable: "head_wic_eligible", value: 0 },
+        { variable: "spouse_wic_eligible", value: 100 },
+        { variable: "snap", value: 50 },
+      ],
+      weights,
+    ),
+    50,
+  );
+});
+
+test("program selection normalizes groups and keeps at least one active", () => {
+  const options = ["person_wic_eligible", "snap"];
+
+  assert.deepEqual(
+    [...resolveActiveProgramIds(options, new Set(["head_wic_eligible"]))],
+    ["person_wic_eligible"],
+  );
+  assert.deepEqual([...selectOnlyProgram("spouse_wic_eligible")], [
+    "person_wic_eligible",
+  ]);
+  assert.deepEqual(
+    [
+      ...toggleProgramSelection(
+        options,
+        new Set(["person_wic_eligible"]),
+        "head_wic_eligible",
+      ),
+    ],
+    ["person_wic_eligible"],
+  );
+});

--- a/paper/index.qmd
+++ b/paper/index.qmd
@@ -934,7 +934,7 @@ snapshot_provenance = pd.DataFrame(
         ["UK scenario-source SHA-256", UK_TRANSFER_ARTIFACT_SHA256],
         ["Households", "100 US and 100 UK"],
         ["Models", f"{len(global_model)} shared models"],
-        ["Output groups", "19 US and 7 UK"],
+        ["Output groups", "18 US and 7 UK"],
         ["Condition", "No tools, no web access, one structured response per household"],
         ["Response contract", "Numeric answer and non-empty explanation for every requested output"],
     ],
@@ -944,7 +944,6 @@ scope_rationale = pd.DataFrame(
     [
         ["Included", "Direct tax, credit, benefit, health-support, and coverage outputs that a household-facing model could plausibly be asked to estimate from household facts."],
         ["Excluded", "Intermediate tax bases, payroll subcomponents, and outputs that mainly require unavailable history, restricted local market data, restricted program-administration data, or take-up assignment rather than rule calculation."],
-        ["ACA Premium Tax Credit", "Retained as a deliberate health-support output; when local benchmark premiums are not listed, the model must estimate them from the household facts."],
         ["Binary coverage outputs", "Requested as 0/1 eligibility flags and scored as classification tasks; their dollar values are used only as impact-weight proxies, not as requested model outputs."],
         ["WIC", "The benchmark asks for person-level WIC eligibility. It does not ask models to estimate a WIC dollar amount."],
     ],
@@ -967,7 +966,7 @@ parse_repair_summary = pd.DataFrame(
         ["Parser repair", "The parser was extended to recover explicit `value` and non-empty `explanation` blocks from nested, escaped, or partially truncated provider JSON without scraping prose numbers."],
         ["Full-response retries", "Three bounded retry rounds targeted broken country-model-household responses and accepted only fully valid replacement responses."],
         ["Row-level repairs", "A final repair pass retried only rows still missing a parsed numeric value or non-empty explanation, using the same model, household, and output."],
-        ["Final parse coverage", "The repaired manuscript snapshot has zero missing parsed numeric values and zero missing explanations across all 34,656 model-output rows."],
+        ["Final parse coverage", "The repaired manuscript snapshot has zero missing parsed numeric values and zero missing explanations across all 33,456 model-output rows."],
         ["Preservation rule", "The snapshot retains response-retry and row-repair targets, attempts, accepted replacements, rejected rows, and merged prediction files."],
     ],
     columns=["Step", "Finding"],
@@ -1086,7 +1085,7 @@ model_runs
 
 The US benchmark is built from Enhanced Current Population Survey (CPS)-derived households using PolicyEngine US. The sampled households are filtered to keep a single-tax-unit, single-family, single-Supplemental Poverty Measure (SPM)-unit structure with at least one adult and a supported filing status. The 2024 Enhanced CPS source contains 41,314 households; 30,173 (73.0%) pass the filter and form the eligible draw. The 27.0% excluded by the filter include multi-tax-unit households (e.g., adult roommates), multi-family households, multi-SPM-unit households, and households whose head reports a filing status outside the supported set. These excluded compositions are exactly the kind of cases where federal/state credit allocations and benefit-unit rules become hardest, so the eligible draw is a tractable subset rather than the full distribution of US households. Prompts include nonzero promptable raw inputs across relevant entities rather than a hand-curated summary, so the models see many of the same facts the simulator receives. Filing status is not stated in the prompt; the reference computation infers it from tax-unit role flags. Models therefore see the same household facts that drive the reference filing-status assignment, but they do not receive that assignment as a label.
 
-The current US release evaluates 19 output groups spanning federal income tax, refundable credits, payroll and self-employment tax, state and local income tax, Supplemental Nutrition Assistance Program (SNAP), Supplemental Security Income (SSI), Temporary Assistance for Needy Families (TANF), Affordable Care Act (ACA) premium tax credits, school-meal eligibility, and person-level coverage eligibility for the Special Supplemental Nutrition Program for Women, Infants, and Children (WIC), Medicaid, the Children's Health Insurance Program (CHIP), Medicare, Head Start, and Early Head Start.
+The current US release evaluates 18 output groups spanning federal income tax, refundable credits, payroll and self-employment tax, state and local income tax, Supplemental Nutrition Assistance Program (SNAP), Supplemental Security Income (SSI), Temporary Assistance for Needy Families (TANF), school-meal eligibility, and person-level coverage eligibility for the Special Supplemental Nutrition Program for Women, Infants, and Children (WIC), Medicaid, the Children's Health Insurance Program (CHIP), Medicare, Head Start, and Early Head Start.
 
 The output scope is intentionally narrower than the full PolicyEngine model. @tbl-scope-rationale summarizes the inclusion rule. The benchmark asks for WIC eligibility rather than a WIC dollar amount; WIC dollar values are used only as impact-weight proxies for coverage flags, not as requested model outputs.
 

--- a/paper/snapshot/20260501/manifest.json
+++ b/paper/snapshot/20260501/manifest.json
@@ -66,7 +66,7 @@
       "files": {
         "figures/global_leaderboard.png": "526511477880573c4e7cae98e3d966eb400eecf7e44c807ddcd4a5d377ebcd6f",
         "figures/positive_zero_scatter.png": "b15332fdda92c8f23269937c90968fb50327186fb154bc29729264586dc463d5",
-        "index.html": "cd72096f22179ed8cc919b5d61ea8441488bd11cc9e8bccc06d44a874aac6196",
+        "index.html": "1a45bc2d3d15c3592106fbaa2b5eeea4c2e23ceacf348c464e49387f8bb2b8b9",
         "pe-tokens.css": "8f24d8da26f583c8ffddffcdcd172b6d52cbecfec20eda55bd39d7aa829f41d8",
         "policybench-theme.css": "0e12c5fd615558259e5bce0167a38424e54f9ceb280666c4afd660d759cd1cb9",
         "site_libs/clipboard/clipboard.min.js": "e17a1d816e13c0826e0ed7febfabc3277f45571234bde0bf9120829a7169edc9",


### PR DESCRIPTION
## Summary
- stagger the sticky header background and compact brand/nav reveal so the compact title does not fade over the hero heading
- make the mobile benchmark header fully populated from the top, with country pills and section tabs fitting at phone widths
- make the paper page header scroll normally instead of staying sticky over the manuscript
- remove the Global tab and default visitors to US unless browser timezone/language indicates UK
- reorder the app flow to model rankings -> program breakdown -> scenarios -> failures -> methodology
- keep the default model-ranking path upfront and move scoring/reference/weighting controls into a collapsed Adjust ranking panel below the table
- move scenario explanation/audit coverage and exact prompt below the household output table
- move What the error reads show into the failures section
- make scenario prediction values visibly interactive and align the program legend with the table color thresholds
- rename the failure-mode callout from "Read this carefully" to "How to read these cards"
- remove the Hardest household segments section from failure modes
- add the teal PolicyEngine mark as the site favicon
- remove ACA premium tax credit from rendered website payloads, public paper/scoring pages, prompts, program displays, weights, and displayed scoring

Fixes #44.

## Testing
- npm run lint
- npm run build
- rendered text check confirms the section order is model rankings -> program breakdown -> scenario explorer -> failures -> methodology
- rendered text check for /, /paper, and /metric-options.html found no ACA/Marketplace/premium tax credit terms
- Playwright screenshots: desktop benchmark flow, mobile benchmark flow, mobile paper, scrolled mobile paper, UK timezone default