### PR TITLE
Hero: drop the within-1% subtitle continuation

### DIFF
--- a/app/src/components/Hero.tsx
+++ b/app/src/components/Hero.tsx
@@ -62,10 +62,7 @@ export default function Hero({
           </span>
 
           <p className="mt-5 text-text-secondary text-sm sm:text-base max-w-xl leading-relaxed">
-            {subtitle}{" "}
-            <span className="text-text-muted">
-              100% = predictions within 1% of the reference across the full benchmark.
-            </span>
+            {subtitle}
           </p>
 
           <div className="flex flex-wrap items-center gap-x-6 gap-y-3 mt-4">


### PR DESCRIPTION
## Summary

Drop the muted "100% = predictions within 1% of the reference across the full benchmark." continuation from the hero subtitle. The leaderboard's `WITHIN 1%` column heading sits right below the hero, so the explainer was redundant.

## Test plan

- [x] `bun run lint` clean
- [x] Visual: hero subtitle now reads "Testing how accurately language models calculate household taxes and benefits." with no muted continuation

🤖 Generated with [Claude Code](https://claude.com/claude-code)
