### PR TITLE
Make the paper render hermetic; render-check it in CI

### DIFF
--- a/.github/workflows/paper.yml
+++ b/.github/workflows/paper.yml
@@ -1,0 +1,58 @@
+name: Paper
+
+# Proves the manuscript renders from a clean, hermetic environment: the render
+# always executes the invoking virtualenv's policybench (no reliance on a
+# user-level Jupyter kernelspec). Gated to paper/code/dependency changes so the
+# heavier quarto render does not run on unrelated pushes.
+on:
+  push:
+    branches: [main]
+    paths:
+      - "paper/**"
+      - "policybench/**"
+      - "pyproject.toml"
+      - "uv.lock"
+      - ".github/workflows/paper.yml"
+  pull_request:
+    branches: [main]
+    paths:
+      - "paper/**"
+      - "policybench/**"
+      - "pyproject.toml"
+      - "uv.lock"
+      - ".github/workflows/paper.yml"
+
+jobs:
+  paper:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+      - run: pip install uv
+      - run: uv sync --locked --extra dev --extra docs
+      - uses: quarto-dev/quarto-actions/setup@v2
+      # rsvg-convert (librsvg2-bin) converts the generated SVG figure to the PNG
+      # that the manuscript embeds. Without it generate_figures.py emits only the
+      # SVG and the render fails on the missing figures/positive_zero_scatter.png.
+      - name: Install rsvg-convert
+        run: sudo apt-get update && sudo apt-get install -y librsvg2-bin
+      # Pin the Jupyter engine to this venv's python. QUARTO_PYTHON selects the
+      # interpreter; JUPYTER_PREFER_ENV_PATH=1 makes Jupyter resolve the `python3`
+      # kernel from the venv's share/jupyter (not a shadowing user kernelspec), so
+      # the render executes this checkout's policybench. The render fails the job
+      # if any notebook cell errors. HTML only — PDF/TeX is skipped in CI. Output
+      # goes to paper/out (gitignored); nothing rendered is committed.
+      - name: Render paper (HTML only)
+        env:
+          JUPYTER_PREFER_ENV_PATH: "1"
+        run: |
+          QUARTO_PYTHON="$(uv run python -c 'import sys; print(sys.executable)')"
+          export QUARTO_PYTHON
+          uv run python paper/generate_figures.py
+          cd paper
+          uv run quarto render index.qmd \
+            --to html \
+            --output-dir out/ci-web \
+            --execute-daemon 0

--- a/paper/README.md
+++ b/paper/README.md
@@ -15,23 +15,22 @@ Suggested workflow:
    cd app && bun install --frozen-lockfile && cd ..
    ```
 
-2. Render the manuscript:
+2. Install the render environment and render the manuscript:
 
    ```bash
-   ./.venv/bin/python paper/render_paper.py
+   uv sync --extra docs
+   uv run python paper/render_paper.py
    ```
 
 Notes:
 - This scaffold assumes `quarto` and the app dependencies are installed
   separately. The renderer reads PolicyEngine design-system tokens from
   `app/node_modules/@policyengine/design-system/dist/tokens.css`.
-- The render venv needs the `policybench` package (editable, from the same
-  checkout being rendered) plus `ipykernel`, `nbformat`, and `nbclient`, and a
-  Jupyter kernelspec named `policybench-paper` pointing at that venv's Python
-  (`python -m ipykernel install --user --name policybench-paper`). A kernelspec
-  that points at a different checkout's venv renders that checkout's
-  `policybench` code instead — set `JUPYTER_PATH` to a scratch kernels
-  directory to override per render.
+- The render is hermetic: it uses the standard `python3` Jupyter kernel pinned
+  to the invoking virtualenv (`render_paper.py` sets `QUARTO_PYTHON` and
+  `JUPYTER_PREFER_ENV_PATH=1`), so it always executes this checkout's
+  `policybench`. No user-level kernelspec needs to be registered. The render
+  environment lives in the `docs` extra (`uv sync --extra docs`).
 - The manuscript tables and figures read from the frozen source run exports
   under `paper/snapshot/20260501/runs/`.
 - `app/src/data.json` is the live site export. For this snapshot it must match

--- a/paper/index.qmd
+++ b/paper/index.qmd
@@ -5,7 +5,7 @@ author:
   - name: "Max Ghenis"
     affiliation: "PolicyEngine"
 bibliography: references.bib
-jupyter: policybench-paper
+jupyter: python3
 format:
   html:
     toc: true

--- a/paper/render_paper.py
+++ b/paper/render_paper.py
@@ -220,14 +220,25 @@ def main() -> None:
     if quarto is None:
         raise SystemExit(
             "Quarto is not installed. Install it first, then rerun "
-            "`./.venv/bin/python paper/render_paper.py`."
+            "`uv run python paper/render_paper.py`."
         )
 
     env = dict(os.environ)
     tex_bin = Path("/Library/TeX/texbin")
     if tex_bin.exists():
         env["PATH"] = f"{tex_bin}:{env.get('PATH', '')}"
+    # Pin the Jupyter engine to the invoking virtualenv so the render always
+    # executes this checkout's policybench. QUARTO_PYTHON selects the
+    # interpreter; QUARTO_PYTHON alone is not enough because Quarto resolves the
+    # `python3` kernel by name and a user-level kernelspec
+    # (~/Library/Jupyter/kernels/python3) can shadow the venv's own kernel and
+    # point at an unrelated checkout. JUPYTER_PREFER_ENV_PATH=1 makes Jupyter
+    # search the venv's share/jupyter ahead of the user directory, so the
+    # `python3` kernelspec resolves to this venv. On a clean machine (e.g. CI)
+    # the venv kernelspec wins anyway; setting it here keeps every invocation
+    # hermetic.
     env["QUARTO_PYTHON"] = sys.executable
+    env["JUPYTER_PREFER_ENV_PATH"] = "1"
 
     snapshot_runs = ROOT / "paper" / "snapshot" / "20260501" / "runs"
     if not snapshot_runs.exists():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,8 @@ dev = [
 docs = [
     "ipykernel>=6.0",
     "jupyter-book>=2.0",
+    "nbformat>=5.0",
+    "nbclient>=0.10",
 ]
 
 [project.scripts]

--- a/uv.lock
+++ b/uv.lock
@@ -2708,6 +2708,8 @@ dev = [
 docs = [
     { name = "ipykernel" },
     { name = "jupyter-book" },
+    { name = "nbclient" },
+    { name = "nbformat" },
 ]
 
 [package.metadata]
@@ -2715,6 +2717,8 @@ requires-dist = [
     { name = "ipykernel", marker = "extra == 'docs'", specifier = ">=6.0" },
     { name = "jupyter-book", marker = "extra == 'docs'", specifier = ">=2.0" },
     { name = "litellm", extras = ["caching"], specifier = ">=1.30" },
+    { name = "nbclient", marker = "extra == 'docs'", specifier = ">=0.10" },
+    { name = "nbformat", marker = "extra == 'docs'", specifier = ">=5.0" },
     { name = "numpy", specifier = ">=1.24" },
     { name = "pandas", specifier = ">=2.0" },
     { name = "policyengine", specifier = ">=4.4.4,<5" },


### PR DESCRIPTION
## Why

The paper render depended on a user-level Jupyter kernelspec (`policybench-paper`) registered against one specific checkout's venv. Rendering from any other checkout silently executed the *other checkout's* `policybench` code, fresh machines couldn't render at all, and the env needed undeclared deps (`nbformat`/`nbclient`). All three bit us during the [#62](https://github.com/PolicyEngine/policybench/pull/62) render.

## What

- `paper/index.qmd` uses the standard `python3` kernel; `render_paper.py` sets `QUARTO_PYTHON` (already did) **plus `JUPYTER_PREFER_ENV_PATH=1`** — the load-bearing discovery: Quarto resolves the `python3` kernel *by name*, and a user-level `~/Library/Jupyter/kernels/python3` can shadow the venv kernel and point at an unrelated checkout (it does on this machine — proven empirically with a probe render that imported the wrong `policybench`). The env var makes Jupyter search the venv's kernels first.
- `nbformat` + `nbclient` declared in the `docs` extra (uv.lock diff: 6 lines, no version changes).
- New `paper.yml` workflow renders the manuscript (HTML-only, no TeX) on PRs touching `paper/**`, `policybench/**`, or dependencies — failing on any notebook cell error. This catches the import-drift class of failure (e.g. a dep bump breaking `policybench` imports the paper executes). The job also runs `generate_figures.py` + installs `librsvg2-bin`, without which the embedded scatter PNG never gets generated and the render fails.
- `paper/README.md`: render flow is now `uv sync --extra docs` + `uv run python paper/render_paper.py`; the kernelspec/JUPYTER_PATH workaround instructions are gone.

Committed rendered artifacts under `app/public/paper/` are untouched — the header change has no effect on them, and CI renders go to gitignored `paper/out/`.

## Verification

- Worktree render with the exact CI env executes the worktree's own `policybench` (probe: `policybench.config.__file__` resolves into the worktree), exit 0, all 19 cells clean.
- `uv run pytest -m "not slow"` (279 passed), ruff clean, `uv sync --locked` consistent, actionlint clean on both workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
