### PR TITLE
Add protected evaluation split machinery to reference-output generation

### DIFF
--- a/docs/benchmark_card.md
+++ b/docs/benchmark_card.md
@@ -107,6 +107,45 @@ open-set benchmark with possible leakage from released cases into future model
 behavior or benchmark-specific prompting. Future protected leaderboard claims
 require a separate held-out or rotating evaluation set.
 
+## Protected split
+
+`policybench reference-outputs --private-fraction <f> --split-seed <n>`
+reserves a deterministic subset of sampled households for a private
+evaluation split. Public files keep their standard names, so every existing
+consumer is unaffected; the private split goes to sibling
+`reference_outputs-private.csv` / `scenarios-private.csv` files (with
+`.meta.json` sidecars recording `split`, `private_fraction`, and
+`split_seed`). Membership is a pure function of the scenario id and the split
+seed, so regeneration reproduces the same partition regardless of sampling
+order.
+
+Discipline for private files:
+
+- Never commit them, publish them, or pass them to dashboard exports. Only
+  aggregate scores from the private split may be released.
+- Run evaluations on the private split by passing the private manifest
+  explicitly (`--scenario-manifest .../scenarios-private.csv`); the eval and
+  analyze commands need no other changes.
+- Activation is a snapshot decision: the current 2026-05-20 snapshot predates
+  the split and remains fully public. The first snapshot that reports
+  protected scores should state both splits' sizes and the split seed's
+  custody (who can regenerate membership).
+- Prompt canaries (unique strings embedded in private-split prompts to detect
+  future training contamination) are planned for the same snapshot that
+  activates the split, since adding them changes prompt text and therefore
+  benchmark identity.
+
+## Evaluation conditions
+
+The benchmark currently has one condition, `no_tools`. That label is attached
+at dashboard-export time (`build_dashboard_payload` in
+`policybench/analysis.py`), not carried through run artifacts: prediction
+CSVs have no condition column, and the eval loop does not parameterize it.
+Adding a second condition (web search, tool-assisted) therefore requires
+threading a `condition` field through run storage and analysis before the
+export — tracked as part of the run-store cutover — rather than new UI work;
+the site's types and leaderboard already filter on `condition`.
+
 ## Country data paths
 
 ### United States

--- a/policybench/cli.py
+++ b/policybench/cli.py
@@ -19,6 +19,12 @@ def _ensure_parent_dir(output_path: str) -> None:
     Path(output_path).parent.mkdir(parents=True, exist_ok=True)
 
 
+def _private_sibling_path(output_path: str | Path) -> Path:
+    """Sibling path for private-split files, e.g. scenarios-private.csv."""
+    path = Path(output_path)
+    return path.with_name(f"{path.stem}-private{path.suffix}")
+
+
 def _write_metadata(output_path: str, metadata: dict) -> None:
     Path(f"{output_path}.meta.json").write_text(
         json.dumps(metadata, indent=2, sort_keys=True),
@@ -183,6 +189,22 @@ def main():
         "--exclude-scenario-manifest",
         default=None,
         help="Existing scenario manifest whose sampled households should be excluded",
+    )
+    gt_parser.add_argument(
+        "--private-fraction",
+        type=float,
+        default=0.0,
+        help=(
+            "Fraction of households to reserve for a private evaluation "
+            "split, written to sibling *-private files that are never "
+            "exported to the public dashboard"
+        ),
+    )
+    gt_parser.add_argument(
+        "--split-seed",
+        type=int,
+        default=1042,
+        help="Seed controlling private-split membership",
     )
 
     # Eval no tools
@@ -682,47 +704,94 @@ def main():
     if args.command == "reference-outputs":
         from policybench.ground_truth import calculate_ground_truth
         from policybench.policyengine_runtime import runtime_metadata_for_country
-        from policybench.scenarios import get_uk_dataset_path, scenario_manifest
+        from policybench.scenarios import (
+            get_uk_dataset_path,
+            scenario_manifest,
+            split_scenarios,
+        )
 
         scenarios, scenario_manifest_input = _load_reference_scenarios(args)
         programs = _parse_programs(
             args.programs,
             get_programs(args.country, args.program_set),
         )
+        # Reference outputs are computed once for every household, then
+        # partitioned: the private split goes to *-private sibling files that
+        # stay out of public exports (see docs/benchmark_card.md).
         df = calculate_ground_truth(scenarios, programs=programs)
-        _ensure_parent_dir(args.output)
-        df.to_csv(args.output, index=False)
-        _ensure_parent_dir(args.scenario_manifest_output)
-        scenario_manifest(scenarios).to_csv(args.scenario_manifest_output, index=False)
+        public_scenarios, private_scenarios = split_scenarios(
+            scenarios,
+            args.private_fraction,
+            args.split_seed,
+        )
+        public_ids = {scenario.id for scenario in public_scenarios}
         source_dataset_path = get_uk_dataset_path() if args.country == "uk" else None
-        metadata = {
+        base_metadata = {
             "metadata_version": 1,
-            "task": "reference_outputs",
             "generated_at_utc": datetime.now(timezone.utc).isoformat(),
             "country": args.country,
-            "num_scenarios": len(scenarios),
             "requested_num_scenarios": args.num_scenarios,
             "seed": args.seed,
             "program_set": args.program_set,
             "programs": sorted(programs),
-            "output": args.output,
-            "scenario_manifest_output": args.scenario_manifest_output,
             "scenario_manifest_input": scenario_manifest_input,
+            "private_fraction": args.private_fraction,
+            "split_seed": args.split_seed,
             **runtime_metadata_for_country(
                 args.country,
                 source_dataset_path=source_dataset_path,
             ),
         }
-        _write_metadata(args.output, metadata)
-        _write_metadata(
-            args.scenario_manifest_output,
-            {
-                **metadata,
-                "task": "scenario_manifest",
-            },
-        )
-        print(f"PolicyEngine reference outputs saved to {args.output}")
-        print(f"Scenario manifest saved to {args.scenario_manifest_output}")
+
+        splits = [
+            (
+                "public",
+                public_scenarios,
+                Path(args.output),
+                Path(args.scenario_manifest_output),
+            )
+        ]
+        if private_scenarios:
+            splits.append(
+                (
+                    "private",
+                    private_scenarios,
+                    _private_sibling_path(args.output),
+                    _private_sibling_path(args.scenario_manifest_output),
+                )
+            )
+
+        for split_name, split_scenarios_list, output_path, manifest_path in splits:
+            split_ids = {scenario.id for scenario in split_scenarios_list}
+            split_df = df[df["scenario_id"].isin(split_ids)].reset_index(drop=True)
+            _ensure_parent_dir(str(output_path))
+            split_df.to_csv(output_path, index=False)
+            _ensure_parent_dir(str(manifest_path))
+            scenario_manifest(split_scenarios_list).to_csv(manifest_path, index=False)
+            split_metadata = {
+                **base_metadata,
+                "task": "reference_outputs",
+                "split": split_name,
+                "num_scenarios": len(split_scenarios_list),
+                "output": str(output_path),
+                "scenario_manifest_output": str(manifest_path),
+            }
+            _write_metadata(str(output_path), split_metadata)
+            _write_metadata(
+                str(manifest_path),
+                {**split_metadata, "task": "scenario_manifest"},
+            )
+            label = "" if split_name == "public" else " (private split)"
+            print(f"PolicyEngine reference outputs{label} saved to {output_path}")
+            print(f"Scenario manifest{label} saved to {manifest_path}")
+        if private_scenarios:
+            print(
+                f"Private split: {len(private_scenarios)} of "
+                f"{len(public_ids) + len(private_scenarios)} households "
+                f"(fraction {args.private_fraction}, split seed "
+                f"{args.split_seed}). Keep *-private files out of public "
+                "artifacts."
+            )
 
     elif args.command == "eval-no-tools":
         from policybench.eval_no_tools import (

--- a/policybench/scenarios.py
+++ b/policybench/scenarios.py
@@ -1428,3 +1428,37 @@ def generate_scenarios(
             excluded_household_ids=excluded_household_ids,
         )
     raise ValueError(f"Unsupported country '{country}'")
+
+
+def split_scenarios(
+    scenarios: list[Scenario],
+    private_fraction: float,
+    seed: int,
+) -> tuple[list[Scenario], list[Scenario]]:
+    """Deterministically partition scenarios into (public, private) splits.
+
+    The private split is a uniformly sampled subset whose membership depends
+    only on ``seed`` and the scenario ids, so re-running reference-output
+    generation with the same inputs reproduces the same partition. Both
+    splits preserve the input ordering.
+    """
+    if not 0.0 <= private_fraction < 1.0:
+        raise ValueError(f"private_fraction must be in [0, 1), got {private_fraction}")
+    if private_fraction == 0.0:
+        return list(scenarios), []
+
+    private_count = round(len(scenarios) * private_fraction)
+    if private_count == 0:
+        return list(scenarios), []
+
+    # Rank by a seeded hash of each scenario id rather than random.sample so
+    # membership is a pure function of (id, seed), independent of list order.
+    def membership_rank(scenario: Scenario) -> str:
+        digest = hashlib.sha256(f"{seed}:{scenario.id}".encode("utf-8"))
+        return digest.hexdigest()
+
+    ranked = sorted(scenarios, key=membership_rank)
+    private_ids = {scenario.id for scenario in ranked[:private_count]}
+    public = [s for s in scenarios if s.id not in private_ids]
+    private = [s for s in scenarios if s.id in private_ids]
+    return public, private

--- a/tests/test_protected_split.py
+++ b/tests/test_protected_split.py
@@ -1,0 +1,197 @@
+"""Tests for the protected evaluation split."""
+
+import json
+import sys
+from unittest.mock import patch
+
+import pandas as pd
+import pytest
+
+from policybench.cli import _private_sibling_path, main
+from policybench.scenarios import Person, Scenario, split_scenarios
+
+
+def make_scenarios(count: int) -> list[Scenario]:
+    return [
+        Scenario(
+            id=f"scenario_{index:03d}",
+            country="us",
+            state="CA",
+            filing_status="single",
+            adults=[Person(name="head", age=30 + index, employment_income=40_000.0)],
+            year=2026,
+        )
+        for index in range(count)
+    ]
+
+
+def test_split_is_deterministic_and_disjoint():
+    scenarios = make_scenarios(20)
+    public_a, private_a = split_scenarios(scenarios, 0.25, seed=7)
+    public_b, private_b = split_scenarios(scenarios, 0.25, seed=7)
+
+    assert [s.id for s in public_a] == [s.id for s in public_b]
+    assert [s.id for s in private_a] == [s.id for s in private_b]
+    assert len(private_a) == 5
+    assert {s.id for s in public_a} | {s.id for s in private_a} == {
+        s.id for s in scenarios
+    }
+    assert {s.id for s in public_a} & {s.id for s in private_a} == set()
+
+
+def test_split_membership_is_order_independent():
+    scenarios = make_scenarios(20)
+    _, private_forward = split_scenarios(scenarios, 0.3, seed=11)
+    _, private_reversed = split_scenarios(list(reversed(scenarios)), 0.3, seed=11)
+    assert {s.id for s in private_forward} == {s.id for s in private_reversed}
+
+
+def test_split_preserves_input_order():
+    scenarios = make_scenarios(10)
+    public, private = split_scenarios(scenarios, 0.4, seed=3)
+    original_order = [s.id for s in scenarios]
+    assert [s.id for s in public] == [
+        sid for sid in original_order if sid in {s.id for s in public}
+    ]
+    assert [s.id for s in private] == [
+        sid for sid in original_order if sid in {s.id for s in private}
+    ]
+
+
+def test_seed_changes_membership():
+    scenarios = make_scenarios(40)
+    _, private_a = split_scenarios(scenarios, 0.5, seed=1)
+    _, private_b = split_scenarios(scenarios, 0.5, seed=2)
+    assert {s.id for s in private_a} != {s.id for s in private_b}
+
+
+def test_zero_fraction_returns_everything_public():
+    scenarios = make_scenarios(5)
+    public, private = split_scenarios(scenarios, 0.0, seed=1)
+    assert [s.id for s in public] == [s.id for s in scenarios]
+    assert private == []
+
+
+def test_tiny_fraction_rounds_to_zero():
+    scenarios = make_scenarios(4)
+    public, private = split_scenarios(scenarios, 0.1, seed=1)
+    assert len(public) == 4
+    assert private == []
+
+
+def test_invalid_fraction_raises():
+    scenarios = make_scenarios(3)
+    with pytest.raises(ValueError, match="private_fraction"):
+        split_scenarios(scenarios, 1.0, seed=1)
+    with pytest.raises(ValueError, match="private_fraction"):
+        split_scenarios(scenarios, -0.1, seed=1)
+
+
+def test_private_sibling_path():
+    assert str(_private_sibling_path("results/local/scenarios.csv")) == (
+        "results/local/scenarios-private.csv"
+    )
+
+
+def _fake_ground_truth(scenarios, programs):
+    return pd.DataFrame(
+        {
+            "scenario_id": [scenario.id for scenario in scenarios],
+            "variable": ["snap"] * len(scenarios),
+            "value": [100.0] * len(scenarios),
+        }
+    )
+
+
+def test_reference_outputs_cli_writes_private_split(tmp_path):
+    scenarios = make_scenarios(10)
+    output = tmp_path / "reference_outputs.csv"
+    manifest = tmp_path / "scenarios.csv"
+    argv = [
+        "policybench",
+        "reference-outputs",
+        "-o",
+        str(output),
+        "--scenario-manifest-output",
+        str(manifest),
+        "--private-fraction",
+        "0.3",
+        "--split-seed",
+        "5",
+    ]
+    with (
+        patch(
+            "policybench.cli._load_reference_scenarios",
+            return_value=(scenarios, None),
+        ),
+        patch(
+            "policybench.ground_truth.calculate_ground_truth",
+            side_effect=_fake_ground_truth,
+        ),
+        patch(
+            "policybench.policyengine_runtime.runtime_metadata_for_country",
+            return_value={},
+        ),
+        patch.object(sys, "argv", argv),
+    ):
+        main()
+
+    private_output = tmp_path / "reference_outputs-private.csv"
+    private_manifest = tmp_path / "scenarios-private.csv"
+    assert output.exists() and manifest.exists()
+    assert private_output.exists() and private_manifest.exists()
+
+    public_ids = set(pd.read_csv(manifest)["scenario_id"])
+    private_ids = set(pd.read_csv(private_manifest)["scenario_id"])
+    assert len(private_ids) == 3
+    assert public_ids | private_ids == {s.id for s in scenarios}
+    assert public_ids & private_ids == set()
+    assert set(pd.read_csv(output)["scenario_id"]) == public_ids
+    assert set(pd.read_csv(private_output)["scenario_id"]) == private_ids
+
+    public_meta = json.loads((tmp_path / "scenarios.csv.meta.json").read_text())
+    private_meta = json.loads(
+        (tmp_path / "scenarios-private.csv.meta.json").read_text()
+    )
+    assert public_meta["split"] == "public"
+    assert public_meta["num_scenarios"] == 7
+    assert private_meta["split"] == "private"
+    assert private_meta["num_scenarios"] == 3
+    assert private_meta["private_fraction"] == 0.3
+    assert private_meta["split_seed"] == 5
+
+
+def test_reference_outputs_cli_default_has_no_private_files(tmp_path):
+    scenarios = make_scenarios(4)
+    output = tmp_path / "reference_outputs.csv"
+    manifest = tmp_path / "scenarios.csv"
+    argv = [
+        "policybench",
+        "reference-outputs",
+        "-o",
+        str(output),
+        "--scenario-manifest-output",
+        str(manifest),
+    ]
+    with (
+        patch(
+            "policybench.cli._load_reference_scenarios",
+            return_value=(scenarios, None),
+        ),
+        patch(
+            "policybench.ground_truth.calculate_ground_truth",
+            side_effect=_fake_ground_truth,
+        ),
+        patch(
+            "policybench.policyengine_runtime.runtime_metadata_for_country",
+            return_value={},
+        ),
+        patch.object(sys, "argv", argv),
+    ):
+        main()
+
+    assert output.exists()
+    assert not (tmp_path / "reference_outputs-private.csv").exists()
+    meta = json.loads((tmp_path / "reference_outputs.csv.meta.json").read_text())
+    assert meta["split"] == "public"
+    assert meta["num_scenarios"] == 4


### PR DESCRIPTION
## Why

The paper names open-set leakage as the central limitation and calls for protected evaluation sets. Retrofitting a split at the next snapshot is much easier if the machinery already exists and is exercised.

## What

- `policybench reference-outputs --private-fraction f --split-seed n` reserves a deterministic subset of households for a private split, written to sibling `*-private` files (reference outputs, scenario manifest, `.meta.json` sidecars recording `split`, `private_fraction`, `split_seed`).
- Membership is a pure function of (scenario id, split seed) — a seeded-hash ranking, not `random.sample` — so regeneration reproduces the partition regardless of sampling order. Tested for determinism, order-independence, disjointness, and rounding edge cases, plus two full CLI dispatch tests with mocked ground truth.
- Public files keep their standard names and the default fraction is 0: zero behavior change for existing consumers and the in-flight refresh. Private-split evals just pass the private manifest path to the existing commands.
- Benchmark card documents the discipline (never publish private files; prompt canaries activate with the same future snapshot, since they change benchmark identity) and records the condition-plumbing audit: `no_tools` is attached at export time, not carried through run artifacts, so a second condition routes through run storage, not UI.

## Verification

289 tests pass (10 new), ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
