### PR TITLE
Add per-model pages and explorer deep links

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -153,6 +153,9 @@ export default function App() {
     if (typeof window !== "undefined") {
       const url = new URL(window.location.href);
       url.searchParams.set("country", view);
+      // Scenario ids and prediction cells are country-specific.
+      url.searchParams.delete("scenario");
+      url.searchParams.delete("cell");
       window.history.replaceState(null, "", url);
     }
   };

--- a/app/src/app/model/[id]/page.tsx
+++ b/app/src/app/model/[id]/page.tsx
@@ -1,0 +1,318 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+
+import rawData from "../../../data-summary.json";
+import SiteHeader from "../../../components/SiteHeader";
+import ProviderMark from "../../../components/ProviderMark";
+import { formatCurrency } from "../../../format";
+import {
+  coverageAccuracy,
+  hardestCases,
+  listModels,
+  modelCountrySummaries,
+  programRows,
+} from "../../../lib/modelPage";
+import { MODEL_LABELS, getProviderForModel, PROVIDER_LABELS } from "../../../modelMeta";
+import {
+  getVariableLabel,
+  VIEW_LABELS,
+  type DashboardBundle,
+} from "../../../types";
+
+const dashboard = rawData as DashboardBundle;
+
+export const dynamicParams = false;
+
+export function generateStaticParams() {
+  return listModels(dashboard).map((id) => ({ id }));
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}): Promise<Metadata> {
+  const { id } = await params;
+  const label = MODEL_LABELS[id] ?? id;
+  const summaries = modelCountrySummaries(dashboard, id);
+  const scoreText = summaries
+    .map(
+      (summary) =>
+        `${summary.country.toUpperCase()} ${(summary.stat.within1pct ?? summary.stat.score).toFixed(1)}%`,
+    )
+    .join(", ");
+  const description =
+    `How accurately ${label} estimates household tax and benefit amounts ` +
+    `without tools, scored against PolicyEngine (within-1% hit rate: ` +
+    `${scoreText}).`;
+  return {
+    title: label,
+    description,
+    alternates: { canonical: `/model/${id}` },
+    openGraph: {
+      title: `${label} on PolicyBench`,
+      description,
+      images: [{ url: "/og-image.png", width: 1200, height: 630 }],
+    },
+    twitter: {
+      card: "summary_large_image",
+      title: `${label} on PolicyBench`,
+      description,
+    },
+  };
+}
+
+function formatPct(value: number | null | undefined): string {
+  return value === null || value === undefined ? "—" : `${value.toFixed(1)}%`;
+}
+
+function ScorePill({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-xl border border-border bg-card px-4 py-3">
+      <div className="text-[10px] uppercase tracking-[0.14em] text-text-muted font-medium">
+        {label}
+      </div>
+      <div className="mt-1 font-[family-name:var(--font-mono)] text-xl text-text">
+        {value}
+      </div>
+    </div>
+  );
+}
+
+export default async function ModelPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  const summaries = modelCountrySummaries(dashboard, id);
+  if (summaries.length === 0) notFound();
+
+  const label = MODEL_LABELS[id] ?? id;
+  const provider = getProviderForModel(id);
+  const providerLabel = provider ? PROVIDER_LABELS[provider] : null;
+
+  const expanded = (
+    <div>
+      <div className="flex items-center gap-3">
+        <ProviderMark provider={provider} size={28} />
+        <div>
+          <h1 className="font-[family-name:var(--font-display)] text-3xl sm:text-4xl text-text tracking-tight">
+            {label}
+          </h1>
+          {providerLabel && (
+            <div className="mt-1 text-sm text-text-secondary">
+              {providerLabel} · AI alone, no tools
+            </div>
+          )}
+        </div>
+      </div>
+      <div className="mt-6 grid grid-cols-2 gap-3 sm:grid-cols-4 max-w-3xl">
+        {summaries.map((summary) => (
+          <ScorePill
+            key={`rank-${summary.country}`}
+            label={`${VIEW_LABELS[summary.country]} rank`}
+            value={`#${summary.rank} of ${summary.rankedModels}`}
+          />
+        ))}
+        {summaries.map((summary) => (
+          <ScorePill
+            key={`score-${summary.country}`}
+            label={`${summary.country.toUpperCase()} within 1%`}
+            value={formatPct(summary.stat.within1pct ?? summary.stat.score)}
+          />
+        ))}
+      </div>
+    </div>
+  );
+
+  return (
+    <main id="main" className="min-h-screen bg-void">
+      <SiteHeader
+        actionLink={{ label: "Leaderboard", href: "/", type: "internal" }}
+        expandedContent={expanded}
+        alwaysExpanded
+      />
+
+      <div className="mx-auto max-w-7xl px-4 sm:px-6 pb-20">
+        {summaries.map((summary) => {
+          const bench = dashboard.countries[summary.country];
+          if (!bench) return null;
+          const rows = programRows(bench, id);
+          const cases = hardestCases(bench, id);
+          const coverage = coverageAccuracy(bench, id);
+          const currencySymbol = summary.country === "uk" ? "£" : "$";
+          return (
+            <section
+              key={summary.country}
+              aria-labelledby={`country-${summary.country}`}
+              className="mt-12"
+            >
+              <div className="eyebrow mb-3">
+                {VIEW_LABELS[summary.country]}
+              </div>
+              <h2
+                id={`country-${summary.country}`}
+                className="font-[family-name:var(--font-display)] text-2xl sm:text-3xl text-text tracking-tight"
+              >
+                {VIEW_LABELS[summary.country]} benchmark
+              </h2>
+
+              <div className="mt-5 grid grid-cols-2 gap-3 sm:grid-cols-4 max-w-3xl">
+                <ScorePill
+                  label="Exact match"
+                  value={formatPct(summary.stat.exact)}
+                />
+                <ScorePill
+                  label="Bounded score"
+                  value={formatPct(summary.stat.boundedScore ?? summary.stat.score)}
+                />
+                <ScorePill
+                  label="Parse rate"
+                  value={
+                    summary.stat.n > 0
+                      ? `${((summary.stat.nParsed / summary.stat.n) * 100).toFixed(1)}%`
+                      : "—"
+                  }
+                />
+                <ScorePill
+                  label="Eligibility flags"
+                  value={
+                    coverage
+                      ? `${coverage.correct}/${coverage.total}`
+                      : "—"
+                  }
+                />
+              </div>
+
+              <div className="mt-8 grid gap-8 lg:grid-cols-2">
+                <div>
+                  <h3 className="text-sm font-medium text-text">
+                    Score by program
+                    <span className="ml-2 text-text-muted font-normal">
+                      hardest first
+                    </span>
+                  </h3>
+                  <div className="mt-3 overflow-x-auto rounded-2xl border border-border bg-card">
+                    <table className="w-full border-collapse text-sm">
+                      <thead>
+                        <tr className="border-b border-border-subtle">
+                          <th className="px-4 py-2.5 text-left text-[10px] uppercase tracking-[0.14em] text-text-muted font-medium">
+                            Program
+                          </th>
+                          <th className="px-4 py-2.5 text-right text-[10px] uppercase tracking-[0.14em] text-text-muted font-medium">
+                            Within 1%
+                          </th>
+                          <th className="px-4 py-2.5 text-right text-[10px] uppercase tracking-[0.14em] text-text-muted font-medium">
+                            Exact
+                          </th>
+                          <th className="px-4 py-2.5 text-right text-[10px] uppercase tracking-[0.14em] text-text-muted font-medium">
+                            n
+                          </th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {rows.map((row) => (
+                          <tr
+                            key={row.variable}
+                            className="border-t border-border-subtle first:border-t-0"
+                          >
+                            <td className="px-4 py-2 text-text-secondary">
+                              {getVariableLabel(row.variable, summary.country)}
+                            </td>
+                            <td className="px-4 py-2 text-right font-[family-name:var(--font-mono)] text-text">
+                              {formatPct(row.within1pct)}
+                            </td>
+                            <td className="px-4 py-2 text-right font-[family-name:var(--font-mono)] text-text-secondary">
+                              {formatPct(row.exact)}
+                            </td>
+                            <td className="px-4 py-2 text-right font-[family-name:var(--font-mono)] text-text-muted">
+                              {row.n}
+                            </td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </div>
+                </div>
+
+                <div>
+                  <h3 className="text-sm font-medium text-text">
+                    Hardest cases
+                    <span className="ml-2 text-text-muted font-normal">
+                      worst misses on positive references
+                    </span>
+                  </h3>
+                  <ul className="mt-3 space-y-3">
+                    {cases.length === 0 && (
+                      <li className="rounded-2xl border border-border bg-card px-4 py-3 text-sm text-text-muted">
+                        No misses beyond 1% on positive references.
+                      </li>
+                    )}
+                    {cases.map((entry) => (
+                      <li
+                        key={`${entry.scenarioId}-${entry.variable}`}
+                        className="rounded-2xl border border-border bg-card px-4 py-3"
+                      >
+                        <div className="flex items-baseline justify-between gap-3">
+                          <span className="text-sm text-text">
+                            {getVariableLabel(entry.variable, summary.country)}
+                          </span>
+                          <span className="font-[family-name:var(--font-mono)] text-xs text-danger-text">
+                            {entry.relativeError === null
+                              ? "no parseable answer"
+                              : `${Math.round(entry.relativeError * 100)}% off`}
+                          </span>
+                        </div>
+                        <div className="mt-1 text-xs text-text-secondary">
+                          Reference{" "}
+                          <span className="font-[family-name:var(--font-mono)]">
+                            {formatCurrency(entry.groundTruth, currencySymbol)}
+                          </span>
+                          {entry.prediction !== null && (
+                            <>
+                              {" "}
+                              · predicted{" "}
+                              <span className="font-[family-name:var(--font-mono)]">
+                                {formatCurrency(entry.prediction, currencySymbol)}
+                              </span>
+                            </>
+                          )}
+                        </div>
+                        <Link
+                          href={`/?country=${summary.country}&scenario=${entry.scenarioId}&cell=${encodeURIComponent(`${entry.variable}~${id}`)}#scenarios`}
+                          className="mt-2 inline-block text-xs text-primary-strong hover:text-primary underline underline-offset-2"
+                        >
+                          Inspect household{" "}
+                          {entry.scenarioId.replace("scenario_", "#")}
+                        </Link>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              </div>
+            </section>
+          );
+        })}
+
+        <p className="mt-12 text-xs text-text-muted max-w-2xl leading-relaxed">
+          Scores are from the frozen manuscript snapshot under the AI-alone
+          condition: one structured response per household, no tools, graded
+          against PolicyEngine reference outputs. See the{" "}
+          <Link href="/" className="underline underline-offset-2 hover:text-text">
+            leaderboard
+          </Link>{" "}
+          and{" "}
+          <Link
+            href="/paper"
+            className="underline underline-offset-2 hover:text-text"
+          >
+            paper
+          </Link>{" "}
+          for methodology.
+        </p>
+      </div>
+    </main>
+  );
+}

--- a/app/src/app/sitemap.ts
+++ b/app/src/app/sitemap.ts
@@ -1,6 +1,15 @@
 import type { MetadataRoute } from "next";
 
+import rawData from "../data-summary.json";
+import { listModels } from "../lib/modelPage";
+import type { DashboardBundle } from "../types";
+
 export default function sitemap(): MetadataRoute.Sitemap {
+  const modelEntries = listModels(rawData as DashboardBundle).map((id) => ({
+    url: `https://policybench.org/model/${id}`,
+    changeFrequency: "monthly" as const,
+    priority: 0.6,
+  }));
   return [
     {
       url: "https://policybench.org/",
@@ -12,5 +21,6 @@ export default function sitemap(): MetadataRoute.Sitemap {
       changeFrequency: "monthly",
       priority: 0.7,
     },
+    ...modelEntries,
   ];
 }

--- a/app/src/components/ModelLeaderboard.tsx
+++ b/app/src/components/ModelLeaderboard.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useMemo, useState } from "react";
+import Link from "next/link";
 import type {
   BenchData,
   DashboardBundle,
@@ -328,9 +329,12 @@ export default function ModelLeaderboard({
                         size={14}
                         className="flex-shrink-0"
                       />
-                      <span className="truncate text-sm font-medium text-text">
+                      <Link
+                        href={`/model/${m.model}`}
+                        className="truncate text-sm font-medium text-text hover:text-primary-strong"
+                      >
                         {MODEL_LABELS[m.model] || m.model}
-                      </span>
+                      </Link>
                     </div>
                   </div>
 
@@ -352,9 +356,12 @@ export default function ModelLeaderboard({
                     size={14}
                     className="flex-shrink-0"
                   />
-                  <span className="text-text font-medium text-sm">
+                  <Link
+                    href={`/model/${m.model}`}
+                    className="text-text font-medium text-sm hover:text-primary-strong"
+                  >
                     {MODEL_LABELS[m.model] || m.model}
-                  </span>
+                  </Link>
                 </div>
 
                 <div className="col-span-3 text-right">

--- a/app/src/components/ScenarioExplorer.tsx
+++ b/app/src/components/ScenarioExplorer.tsx
@@ -123,6 +123,28 @@ export default function ScenarioExplorer({
     selectedScenario && data.scenarios[selectedScenario]
       ? selectedScenario
       : scenarioIds[0] ?? null;
+
+  /**
+   * Mirror explorer state into ?scenario= and ?cell=variable~model so any
+   * household or prediction cell is linkable (model pages link straight to
+   * their hardest cases). Uses replaceState — no history spam, no scrolling.
+   */
+  const syncExplorerUrl = (updates: {
+    scenario?: string;
+    cell?: string | null;
+  }) => {
+    if (typeof window === "undefined") return;
+    const url = new URL(window.location.href);
+    if (updates.scenario !== undefined) {
+      url.searchParams.set("scenario", updates.scenario);
+      url.searchParams.delete("cell");
+    }
+    if (updates.cell !== undefined) {
+      if (updates.cell === null) url.searchParams.delete("cell");
+      else url.searchParams.set("cell", updates.cell);
+    }
+    window.history.replaceState(null, "", url);
+  };
   const scenario = resolvedScenarioId ? data.scenarios[resolvedScenarioId] : null;
 
   // Explanation and audit text lives in a per-country sidecar fetched lazily
@@ -251,12 +273,52 @@ export default function ScenarioExplorer({
   // factsText prop, so picking a different household from the dropdown
   // updates the modal in place rather than needing an explicit reset.
 
-  const closeModal = () => setManualSelection(null);
+  // Apply ?scenario= / ?cell= deep links once on mount. Post-mount (via a
+  // zero-delay timer, matching the repo's effect-setState convention) so the
+  // server-rendered default household hydrates cleanly first.
+  useEffect(() => {
+    const apply = () => {
+      const params = new URLSearchParams(window.location.search);
+      const scenarioParam = params.get("scenario");
+      if (!scenarioParam || !data.scenarios[scenarioParam]) return;
+      setSelectedScenario(scenarioParam);
+      const cellParam = params.get("cell");
+      if (!cellParam) return;
+      const separator = cellParam.indexOf("~");
+      if (separator <= 0) return;
+      const variable = cellParam.slice(0, separator);
+      const model = cellParam.slice(separator + 1);
+      if (!data.scenarioPredictions[scenarioParam]?.[variable]) return;
+      setManualSelection({
+        scenarioId: scenarioParam,
+        cell: { variable, model },
+      });
+      // The dialog opens over an inert background, so the viewport-gated
+      // explanation fetch would never trigger — start it now.
+      setExplanationsEnabled(true);
+      // The linked model may be hidden behind the frontier-only default.
+      if (!isFrontierModel(model)) setFrontierOnly(false);
+    };
+    const timer = window.setTimeout(apply, 0);
+    return () => window.clearTimeout(timer);
+    // Run once per country remount; the URL is only read at entry.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const closeModal = () => {
+    setManualSelection(null);
+    syncExplorerUrl({ cell: null });
+  };
   const closeHouseholdModal = () => setHouseholdModalOpen(false);
 
   const setSelectedCell = (cell: { variable: string; model: string }) => {
     if (!resolvedScenarioId) return;
     setManualSelection({ scenarioId: resolvedScenarioId, cell });
+    setExplanationsEnabled(true);
+    syncExplorerUrl({
+      scenario: resolvedScenarioId,
+      cell: `${cell.variable}~${cell.model}`,
+    });
   };
 
   if (!scenario || !resolvedScenarioId) return null;
@@ -315,7 +377,10 @@ export default function ScenarioExplorer({
 
   const handleShuffle = () => {
     const nextScenario = pickRandomScenario(scenarioIds, resolvedScenarioId);
-    if (nextScenario) setSelectedScenario(nextScenario);
+    if (nextScenario) {
+      setSelectedScenario(nextScenario);
+      syncExplorerUrl({ scenario: nextScenario });
+    }
   };
 
   return (
@@ -347,7 +412,10 @@ export default function ScenarioExplorer({
             <select
               id="scenario-select"
               value={resolvedScenarioId}
-              onChange={(e) => setSelectedScenario(e.target.value)}
+              onChange={(e) => {
+                setSelectedScenario(e.target.value);
+                syncExplorerUrl({ scenario: e.target.value });
+              }}
               className="min-w-0 flex-1 bg-surface border border-border text-text text-sm rounded-lg px-3 py-2 focus:border-primary-strong/60 font-[family-name:var(--font-mono)]"
             >
               {scenarioIds.map((id) => {
@@ -935,7 +1003,12 @@ function DetailContent({
               size={14}
               className="flex-shrink-0"
             />
-            {MODEL_LABELS[model] ?? model}
+            <a
+              href={`/model/${model}`}
+              className="hover:text-primary-strong"
+            >
+              {MODEL_LABELS[model] ?? model}
+            </a>
           </div>
         </div>
         <span

--- a/app/src/lib/modelPage.ts
+++ b/app/src/lib/modelPage.ts
@@ -1,0 +1,180 @@
+/**
+ * Server-side selectors for the per-model deep-dive pages (/model/[id]).
+ *
+ * These run at build time over the bundled summary (no explanation text), so
+ * the pages are statically generated and ship no extra client JS.
+ */
+
+import type {
+  BenchData,
+  CountryCode,
+  DashboardBundle,
+  HeatmapEntry,
+  ModelStat,
+} from "../types";
+import { isBinaryVariable } from "../types";
+import { binaryFlag } from "./scoring";
+
+export type ModelCountrySummary = {
+  country: CountryCode;
+  stat: ModelStat;
+  /** Leaderboard position by the headline within-1% metric (1-based). */
+  rank: number;
+  rankedModels: number;
+};
+
+export type ProgramRow = {
+  variable: string;
+  within1pct: number | null;
+  exact: number | null;
+  n: number;
+};
+
+export type HardCase = {
+  scenarioId: string;
+  variable: string;
+  groundTruth: number;
+  prediction: number | null;
+  /** Relative error for positive references; null for unparsed predictions. */
+  relativeError: number | null;
+};
+
+function noToolsStats(bench: BenchData): ModelStat[] {
+  return bench.modelStats.filter((row) => row.condition === "no_tools");
+}
+
+/** Every model present in any country, in leaderboard order of best score. */
+export function listModels(bundle: DashboardBundle): string[] {
+  const best = new Map<string, number>();
+  for (const bench of Object.values(bundle.countries)) {
+    if (!bench) continue;
+    for (const row of noToolsStats(bench)) {
+      const headline = row.within1pct ?? row.score;
+      best.set(row.model, Math.max(best.get(row.model) ?? -Infinity, headline));
+    }
+  }
+  return [...best.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .map(([model]) => model);
+}
+
+export function modelCountrySummaries(
+  bundle: DashboardBundle,
+  model: string,
+): ModelCountrySummary[] {
+  const summaries: ModelCountrySummary[] = [];
+  for (const [country, bench] of Object.entries(bundle.countries) as [
+    CountryCode,
+    BenchData | undefined,
+  ][]) {
+    if (!bench) continue;
+    const rows = noToolsStats(bench).sort(
+      (a, b) => (b.within1pct ?? b.score) - (a.within1pct ?? a.score),
+    );
+    const index = rows.findIndex((row) => row.model === model);
+    if (index === -1) continue;
+    summaries.push({
+      country,
+      stat: rows[index],
+      rank: index + 1,
+      rankedModels: rows.length,
+    });
+  }
+  return summaries;
+}
+
+/** Per-program scores for one model in one country, hardest first. */
+export function programRows(bench: BenchData, model: string): ProgramRow[] {
+  return bench.heatmap
+    .filter(
+      (entry: HeatmapEntry) =>
+        entry.model === model && entry.condition === "no_tools",
+    )
+    .map((entry) => ({
+      variable: entry.variable,
+      within1pct: entry.within1pct ?? null,
+      exact: entry.exact ?? null,
+      n: entry.n,
+    }))
+    .sort((a, b) => (a.within1pct ?? 0) - (b.within1pct ?? 0));
+}
+
+/**
+ * The model's worst misses on positive-dollar references, plus unparsed
+ * responses. Binary eligibility flags are excluded — a flipped flag has no
+ * meaningful error magnitude to rank by.
+ */
+export function hardestCases(
+  bench: BenchData,
+  model: string,
+  limit = 6,
+): HardCase[] {
+  const cases: HardCase[] = [];
+  for (const [scenarioId, variableMap] of Object.entries(
+    bench.scenarioPredictions,
+  )) {
+    for (const [variable, modelMap] of Object.entries(variableMap)) {
+      const record = modelMap[model];
+      if (!record) continue;
+      if (isBinaryVariable(variable, bench.country)) continue;
+      const truth = record.groundTruth;
+      if (record.prediction === null || Number.isNaN(record.prediction)) {
+        cases.push({
+          scenarioId,
+          variable,
+          groundTruth: truth,
+          prediction: null,
+          relativeError: null,
+        });
+        continue;
+      }
+      if (truth === 0) continue;
+      const relativeError = Math.abs(record.prediction - truth) / Math.abs(truth);
+      if (relativeError <= 0.01) continue;
+      cases.push({
+        scenarioId,
+        variable,
+        groundTruth: truth,
+        prediction: record.prediction,
+        relativeError,
+      });
+    }
+  }
+  return cases
+    .sort((a, b) => {
+      // Unparsed responses are the worst failure; then by relative error.
+      if ((a.relativeError === null) !== (b.relativeError === null)) {
+        return a.relativeError === null ? -1 : 1;
+      }
+      return (b.relativeError ?? 0) - (a.relativeError ?? 0);
+    })
+    .slice(0, limit);
+}
+
+/** Share of binary eligibility flags this model got right, or null if none. */
+export function coverageAccuracy(
+  bench: BenchData,
+  model: string,
+): { correct: number; total: number } | null {
+  let correct = 0;
+  let total = 0;
+  for (const variableMap of Object.values(bench.scenarioPredictions)) {
+    for (const [variable, modelMap] of Object.entries(variableMap)) {
+      if (!isBinaryVariable(variable, bench.country)) continue;
+      const record = modelMap[model];
+      if (!record) continue;
+      total += 1;
+      const predictionFlag =
+        record.prediction === null ? null : binaryFlag(record.prediction);
+      const truthFlag = binaryFlag(record.groundTruth);
+      if (
+        predictionFlag !== null &&
+        truthFlag !== null &&
+        predictionFlag === truthFlag
+      ) {
+        correct += 1;
+      }
+    }
+  }
+  return total === 0 ? null : { correct, total };
+}

--- a/app/tests/modelPage.test.ts
+++ b/app/tests/modelPage.test.ts
@@ -1,0 +1,174 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  coverageAccuracy,
+  hardestCases,
+  listModels,
+  modelCountrySummaries,
+  programRows,
+} from "../src/lib/modelPage";
+import type { BenchData, DashboardBundle } from "../src/types";
+
+function makeBench(): BenchData {
+  return {
+    country: "us",
+    scenarios: {
+      scenario_001: {
+        country: "us",
+        state: "CA",
+        numAdults: 1,
+        numChildren: 0,
+        totalIncome: 30000,
+      },
+      scenario_002: {
+        country: "us",
+        state: "TX",
+        numAdults: 2,
+        numChildren: 1,
+        totalIncome: 60000,
+      },
+    },
+    modelStats: [
+      {
+        model: "model-a",
+        condition: "no_tools",
+        score: 90,
+        within1pct: 80,
+        exact: 70,
+        boundedScore: 92,
+        n: 100,
+        nParsed: 98,
+      },
+      {
+        model: "model-b",
+        condition: "no_tools",
+        score: 85,
+        within1pct: 60,
+        exact: 50,
+        boundedScore: 88,
+        n: 100,
+        nParsed: 100,
+      },
+      // A non-headline condition row must never leak into rankings.
+      {
+        model: "model-a",
+        condition: "web_search",
+        score: 99,
+        within1pct: 99,
+        n: 100,
+        nParsed: 100,
+      },
+    ],
+    programStats: [],
+    heatmap: [
+      {
+        model: "model-a",
+        variable: "snap",
+        condition: "no_tools",
+        score: 90,
+        within1pct: 75,
+        exact: 60,
+        mae: 10,
+        n: 50,
+        nParsed: 50,
+        coverage: 100,
+      },
+      {
+        model: "model-a",
+        variable: "ssi",
+        condition: "no_tools",
+        score: 95,
+        within1pct: 95,
+        exact: 90,
+        mae: 2,
+        n: 50,
+        nParsed: 50,
+        coverage: 100,
+      },
+    ],
+    scenarioPredictions: {
+      scenario_001: {
+        snap: {
+          "model-a": { prediction: 200, error: 100, groundTruth: 100 },
+          "model-b": { prediction: 100, error: 0, groundTruth: 100 },
+        },
+        person_wic_eligible: {
+          "model-a": { prediction: 1, error: 0, groundTruth: 1 },
+          "model-b": { prediction: 0, error: -1, groundTruth: 1 },
+        },
+      },
+      scenario_002: {
+        snap: {
+          "model-a": { prediction: null, error: null, groundTruth: 50 },
+        },
+        ssi: {
+          "model-a": { prediction: 101, error: 1, groundTruth: 100 },
+        },
+      },
+    },
+    failureModes: { programs: [], households: [] },
+  };
+}
+
+function makeBundle(): DashboardBundle {
+  return { countries: { us: makeBench() } };
+}
+
+describe("listModels", () => {
+  test("orders by best headline score across countries", () => {
+    expect(listModels(makeBundle())).toEqual(["model-a", "model-b"]);
+  });
+});
+
+describe("modelCountrySummaries", () => {
+  test("ranks within the no_tools condition only", () => {
+    const [summary] = modelCountrySummaries(makeBundle(), "model-b");
+    expect(summary.country).toBe("us");
+    expect(summary.rank).toBe(2);
+    expect(summary.rankedModels).toBe(2);
+    expect(summary.stat.within1pct).toBe(60);
+  });
+
+  test("returns empty for unknown models", () => {
+    expect(modelCountrySummaries(makeBundle(), "missing")).toEqual([]);
+  });
+});
+
+describe("programRows", () => {
+  test("sorts hardest program first", () => {
+    const rows = programRows(makeBench(), "model-a");
+    expect(rows.map((row) => row.variable)).toEqual(["snap", "ssi"]);
+    expect(rows[0].within1pct).toBe(75);
+  });
+});
+
+describe("hardestCases", () => {
+  test("ranks unparsed answers first, then by relative error", () => {
+    const cases = hardestCases(makeBench(), "model-a");
+    expect(cases[0]).toMatchObject({
+      scenarioId: "scenario_002",
+      variable: "snap",
+      prediction: null,
+    });
+    expect(cases[1]).toMatchObject({
+      scenarioId: "scenario_001",
+      variable: "snap",
+      relativeError: 1,
+    });
+    // 1% miss on ssi is within tolerance and excluded; binary flags excluded.
+    expect(cases).toHaveLength(2);
+  });
+});
+
+describe("coverageAccuracy", () => {
+  test("counts binary eligibility flags", () => {
+    expect(coverageAccuracy(makeBench(), "model-a")).toEqual({
+      correct: 1,
+      total: 1,
+    });
+    expect(coverageAccuracy(makeBench(), "model-b")).toEqual({
+      correct: 0,
+      total: 1,
+    });
+  });
+});


### PR DESCRIPTION
> **Stacked on #61** (base `site-perf-seo`). Retarget to `main` after #61 merges. Supersedes draft #23, rebuilt on the split-data stack.

## Why

The site is one page with one shareable parameter (`?country=`). Benchmark sites spread through deep links — "look at this model", "look at this cell" — and per-model pages are where search traffic for "<model> tax accuracy" can land. The visual design stays exactly as is; this is an information-architecture change.

## What

**Per-model pages** (`/model/[id]`, statically generated for all 13 models in the snapshot):
- Country rank + within-1% pills in the header; exact/bounded/parse-rate/eligibility-flag pills per country
- Per-program score table sorted hardest-first (from the heatmap rows)
- "Hardest cases": the model's worst misses on positive references plus unparsed responses, each deep-linking into the explorer at that exact cell
- Server components over the bundled summary — zero extra client JS; per-page metadata + canonical URLs + sitemap entries
- Leaderboard rows and the explorer detail dialog link to them

**Explorer deep links**: `?scenario=scenario_007&cell=snap~claude-opus-4.7` opens that household with that dialog. State mirrors into the URL via `replaceState` on every selection; country switches clear the country-specific params; deep links to non-frontier models disable the frontier-only filter so the linked column is visible.

**Bug found by verification**: the lazy explanation fetch (from #61) was viewport-gated, but `<dialog>.showModal()` makes the background inert — so a deep-linked dialog could never trigger the fetch and sat on "Loading explanation text…" forever. Opening any detail dialog now starts the fetch directly. Screenshots in the thread show before/after.

## Verification

19 bun tests pass (6 new for the page selectors), lint clean, production build generates all 19 static routes, and headless screenshots confirm: model page renders both country sections, and the deep link opens the dialog with derivation + reasoning text fully loaded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
