### PR TITLE
Clarify answer schema vs tool use in benchmark docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,12 @@ year 2026-27.
 
 1. **AI alone**: Models estimate tax/benefit values using only their training knowledge
 
+Models return answers by filling a structured answer schema, transmitted over
+the provider's function-calling or JSON-mode channel. That channel is purely an
+output format: nothing executes, no information flows back to the model, and
+each response is a single round trip, so the condition stays no-tool regardless
+of transport.
+
 ## Benchmark scope
 
 Benchmark outputs are defined in `policybench/benchmark_specs.json`. New CLI

--- a/docs/benchmark_card.md
+++ b/docs/benchmark_card.md
@@ -47,6 +47,13 @@ PolicyBench has one canonical evaluation mode.
 - numeric answers for every requested output
 - one required non-empty explanation for each output
 
+Structured responses are collected through each provider's structured-output
+channel: where the API supports function calling, models fill a single answer
+schema (`submit_outputs`); otherwise they return the same fields in JSON mode.
+This is an output format, not a capability — nothing executes, no result is
+returned to the model, and each response is a single round trip. The benchmark
+remains no-tool in every response transport.
+
 The headline score uses the numeric answers only. Explanations are retained for
 auditing, scenario exploration, and qualitative error analysis; they should not
 be described as faithful reasoning traces.


### PR DESCRIPTION
The no-tools benchmark collects answers through provider function-calling (or JSON mode), which is easy to misread as tool use. This adds one paragraph each to the README condition section and the benchmark card's canonical response contract stating that the answer schema is purely an output format: nothing executes, no information returns to the model, and each response is a single round trip.

Docs-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
