### PR TITLE
Rename stale enhanced_cps identifiers to populace (US path)

### DIFF
--- a/policybench/paper_results.py
+++ b/policybench/paper_results.py
@@ -82,7 +82,7 @@ OUTPUT_DISPLAY_NAMES = {
 # reproducible at build time via, from the repo root::
 #
 #     from policybench import scenarios
-#     df, _ = scenarios.load_enhanced_cps_person_frame()
+#     df, _, _ = scenarios.load_certified_us_person_frame()
 #     df["is_adult"] = df["age"] >= 18
 #     n_people, n_households = len(df), df["household_id"].nunique()
 #     n_eligible = len(scenarios._eligible_households(df))

--- a/policybench/policyengine_runtime.py
+++ b/policybench/policyengine_runtime.py
@@ -20,17 +20,16 @@ DATA_PACKAGES = {
 
 SOURCE_DATA_PROVENANCE = {
     "us": {
-        "data_package": "policyengine-us-data",
-        "data_version": "1.73.0",
-        "default_dataset": "enhanced_cps_2024",
+        "data_package": "populace-us",
+        "default_dataset": "populace_us_2024",
         "default_dataset_uri": (
-            "hf://policyengine/policyengine-us-data/enhanced_cps_2024.h5@1.73.0"
+            "hf://policyengine/populace-us/populace_us_2024.h5"
+            "@populace-us-2024-5da5a95-20260611"
         ),
-        "certified_data_build_id": "policyengine-us-data-1.73.0",
+        "certified_data_build_id": "populace-us-2024-5da5a95-20260611",
         "certified_data_artifact_sha256": (
-            "18cdc668d05311c32ae37364abcea89b0221c27154559667e951c7b19f5b5cbd"
+            "f32c2e5e9098bc6540724fdd5debf963af495da4c29b3a7a63fb53c2a4bb5a34"
         ),
-        "data_build_model_version": "1.647.0",
     },
     "uk": {
         "data_package": "policyengine-uk-data",

--- a/policybench/scenarios.py
+++ b/policybench/scenarios.py
@@ -220,7 +220,7 @@ MONETARY_INCOME_FIELDS = {
     "long_term_capital_gains",
 }
 
-BASE_CPS_COLUMNS = {
+BASE_PERSON_COLUMNS = {
     "person_id": "person_id",
     "household_id": "household_id",
     "tax_unit_id": "tax_unit_id",
@@ -443,7 +443,7 @@ class Scenario:
     household_inputs: dict[str, Any] = field(default_factory=dict)
     year: int = TAX_YEAR
     country: str = DEFAULT_COUNTRY
-    source_dataset: str = "enhanced_cps"
+    source_dataset: str = "populace_us_2024"
     metadata: dict[str, Any] = field(default_factory=dict)
 
     @property
@@ -580,21 +580,28 @@ def scenario_from_dict(data: dict[str, Any]) -> Scenario:
         spm_unit_inputs=dict(data.get("spm_unit_inputs", {})),
         household_inputs=dict(data.get("household_inputs", {})),
         year=int(data.get("year", TAX_YEAR)),
-        source_dataset=str(data.get("source_dataset", "enhanced_cps")),
+        source_dataset=str(data.get("source_dataset", "populace_us_2024")),
         metadata=dict(data.get("metadata", {})),
     )
 
 
-def load_enhanced_cps_person_frame() -> tuple[pd.DataFrame, int]:
-    """Load a person-level frame from the certified US microsimulation dataset."""
+def load_certified_us_person_frame() -> tuple[pd.DataFrame, int, str]:
+    """Load a person-level frame from the certified US microsimulation dataset.
+
+    Returns ``(person_df, dataset_year, dataset_label)``. The label is read
+    from the live simulation's PolicyEngine bundle (``default_dataset``), so it
+    reflects the dataset the run actually materialized -- the certified
+    populace build (``populace_us_2024``) -- rather than a hardcoded name.
+    """
     from policybench.policyengine_runtime import make_us_microsimulation
 
     sim = make_us_microsimulation()
     dataset_year = sim.default_input_period
+    dataset_label = str(sim.policyengine_bundle["default_dataset"])
     input_specs = get_promptable_input_specs()
 
     values = {}
-    for output_name, variable_name in BASE_CPS_COLUMNS.items():
+    for output_name, variable_name in BASE_PERSON_COLUMNS.items():
         values[output_name] = np.asarray(
             sim.calculate(
                 variable_name,
@@ -614,7 +621,7 @@ def load_enhanced_cps_person_frame() -> tuple[pd.DataFrame, int]:
             )
         )
 
-    return pd.DataFrame(values), dataset_year
+    return pd.DataFrame(values), dataset_year, dataset_label
 
 
 def _hash_file(path: Path) -> str:
@@ -1150,9 +1157,16 @@ def scenarios_from_cps_frame(
     seed: int = SEED,
     year: int = TAX_YEAR,
     dataset_year: int | None = None,
+    dataset_label: str | None = None,
     excluded_household_ids: set[int] | None = None,
 ) -> list[Scenario]:
-    """Sample benchmark scenarios from a person-level US source frame."""
+    """Sample benchmark scenarios from a person-level US source frame.
+
+    ``dataset_label`` is the certified dataset name reported by the runtime
+    (e.g. ``populace_us_2024``); when provided it is recorded verbatim as each
+    scenario's ``source_dataset``. When omitted, a neutral populace default is
+    used so generated scenarios are never mislabeled.
+    """
     df = _prepare_cps_frame(person_df)
     eligible_households = _eligible_households(df)
     if excluded_household_ids:
@@ -1179,11 +1193,7 @@ def scenarios_from_cps_frame(
         if dataset_year is not None:
             metadata["dataset_year"] = int(dataset_year)
 
-        source_dataset = (
-            f"enhanced_cps_{int(dataset_year)}"
-            if dataset_year is not None
-            else "enhanced_cps"
-        )
+        source_dataset = dataset_label or "populace_us_2024"
         scenarios.append(
             Scenario(
                 id=f"scenario_{i:03d}",
@@ -1407,13 +1417,14 @@ def generate_scenarios(
 ) -> list[Scenario]:
     """Generate benchmark scenarios for a country."""
     if country == "us":
-        person_df, dataset_year = load_enhanced_cps_person_frame()
+        person_df, dataset_year, dataset_label = load_certified_us_person_frame()
         return scenarios_from_cps_frame(
             person_df,
             n=n,
             seed=seed,
             year=TAX_YEAR,
             dataset_year=dataset_year,
+            dataset_label=dataset_label,
             excluded_household_ids=excluded_household_ids,
         )
     if country == "uk":

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -893,7 +893,7 @@ class TestSummaries:
             ],
             "children": [],
             "year": 2026,
-            "source_dataset": "enhanced_cps_2024",
+            "source_dataset": "populace_us_2024",
             "metadata": {"household_id": 1},
         }
         scenarios_df = pd.DataFrame(
@@ -928,7 +928,7 @@ class TestSummaries:
             ],
             "children": [],
             "year": 2026,
-            "source_dataset": "enhanced_cps_2024",
+            "source_dataset": "populace_us_2024",
             "metadata": {"household_id": 1},
         }
         scenarios_df = pd.DataFrame(

--- a/tests/test_scenarios.py
+++ b/tests/test_scenarios.py
@@ -456,7 +456,7 @@ def test_scenario_structure(sample_person_frame):
         assert len(scenario.adults) >= 1
         assert scenario.num_children >= 0
         assert scenario.year == 2026
-        assert scenario.source_dataset == "enhanced_cps"
+        assert scenario.source_dataset == "populace_us_2024"
 
 
 def test_invalid_households_are_filtered(sample_person_frame):
@@ -868,19 +868,19 @@ def test_pe_household_with_children(family_scenario):
 
 
 def test_generate_scenarios_uses_loader(monkeypatch, sample_person_frame):
-    """Top-level US generation should delegate to the Enhanced CPS loader."""
+    """Top-level US generation should delegate to the certified dataset loader."""
 
     def fake_loader():
-        return sample_person_frame, 2024
+        return sample_person_frame, 2024, "populace_us_2024"
 
     monkeypatch.setattr(
-        "policybench.scenarios.load_enhanced_cps_person_frame", fake_loader
+        "policybench.scenarios.load_certified_us_person_frame", fake_loader
     )
     scenarios = generate_scenarios(n=3, seed=0)
 
     assert len(scenarios) == 3
     assert all(scenario.metadata["dataset_year"] == 2024 for scenario in scenarios)
-    assert all(scenario.source_dataset == "enhanced_cps_2024" for scenario in scenarios)
+    assert all(scenario.source_dataset == "populace_us_2024" for scenario in scenarios)
 
 
 def test_generate_uk_scenarios_uses_loader(monkeypatch, sample_uk_frames):


### PR DESCRIPTION
Code-hygiene refactor. The US benchmark has run on PolicyEngine **populace** since the 4.16.1 refresh — the frozen run metadata records `populace_us_2024` throughout (scenarios, reference outputs, weights), with zero `enhanced_cps`. But several **code identifiers** still carried the pre-populace Enhanced CPS names, and the scenario generator hardcoded `source_dataset` to `enhanced_cps_{year}` regardless of the dataset actually loaded — a latent mislabel the frozen run dodged only because its provenance came from the runtime bundle.

## Changes
- `load_enhanced_cps_person_frame` → `load_certified_us_person_frame`, now returning the dataset label read from the runtime bundle (`default_dataset` = `populace_us_2024`).
- `BASE_CPS_COLUMNS` → `BASE_PERSON_COLUMNS`.
- Scenario `source_dataset` derived from that runtime label instead of a hardcoded `enhanced_cps_{year}` string.
- `SOURCE_DATA_PROVENANCE[\"us\"]` fallback repointed from `enhanced_cps_2024.h5` to the certified populace artifact (de-fuses a landmine that would have loaded the wrong dataset if a bundle ever failed to resolve).
- Affected tests updated.

No behavior change for the frozen run. The **UK** calibrated transfer dataset references (`enhanced_cps_2025.h5`) are the real upstream filename and are intentionally left untouched.

## Verification
- `pytest`: 385 passed, 5 skipped. `ruff check` + `ruff format --check`: clean. No US `enhanced_cps` identifiers remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)