### PR TITLE
Add Google Analytics tracking

### DIFF
--- a/app/src/app/layout.tsx
+++ b/app/src/app/layout.tsx
@@ -1,5 +1,59 @@
 import type { Metadata } from "next";
+import Script from "next/script";
 import "./globals.css";
+
+const GA_MEASUREMENT_ID = "G-2YHG89FY0N";
+const TOOL_NAME = "policybench";
+
+const ANALYTICS_INLINE = `
+window.dataLayer = window.dataLayer || [];
+function gtag(){dataLayer.push(arguments);}
+gtag('js', new Date());
+gtag('config', '${GA_MEASUREMENT_ID}', { tool_name: '${TOOL_NAME}' });
+`;
+
+const SCROLL_INLINE = `
+(function() {
+  var TOOL_NAME = '${TOOL_NAME}';
+  if (typeof window === 'undefined' || !window.gtag) return;
+
+  var scrollFired = {};
+  window.addEventListener('scroll', function() {
+    var docHeight = document.documentElement.scrollHeight - window.innerHeight;
+    if (docHeight <= 0) return;
+    var pct = Math.floor((window.scrollY / docHeight) * 100);
+    [25, 50, 75, 100].forEach(function(m) {
+      if (pct >= m && !scrollFired[m]) {
+        scrollFired[m] = true;
+        window.gtag('event', 'scroll_depth', { percent: m, tool_name: TOOL_NAME });
+      }
+    });
+  }, { passive: true });
+
+  [30, 60, 120, 300].forEach(function(sec) {
+    setTimeout(function() {
+      if (document.visibilityState !== 'hidden') {
+        window.gtag('event', 'time_on_tool', { seconds: sec, tool_name: TOOL_NAME });
+      }
+    }, sec * 1000);
+  });
+
+  document.addEventListener('click', function(e) {
+    var link = e.target && e.target.closest ? e.target.closest('a') : null;
+    if (!link || !link.href) return;
+    try {
+      var url = new URL(link.href, window.location.origin);
+      if (url.hostname && url.hostname !== window.location.hostname) {
+        window.gtag('event', 'outbound_click', {
+          url: link.href,
+          target_hostname: url.hostname,
+          tool_name: TOOL_NAME
+        });
+      }
+    } catch (err) {}
+  });
+})();
+`;
 
 const SITE_URL = "https://policybench.org";
 const SITE_TITLE = "PolicyBench, by PolicyEngine";
@@ -60,6 +114,16 @@ export default function RootLayout({
           Skip to main content
         </a>
         {children}
+        <Script
+          src={`https://www.googletagmanager.com/gtag/js?id=${GA_MEASUREMENT_ID}`}
+          strategy="afterInteractive"
+        />
+        <Script id="ga-init" strategy="afterInteractive">
+          {ANALYTICS_INLINE}
+        </Script>
+        <Script id="scroll-tracking" strategy="afterInteractive">
+          {SCROLL_INLINE}
+        </Script>
       </body>
     </html>
   );


### PR DESCRIPTION
## Summary

PolicyBench launched without the standard PolicyEngine analytics tag, so traffic isn't being tracked. This adds it.

- Adds the shared **tools GA4 property `G-2YHG89FY0N`** with `tool_name: 'policybench'`, matching the pattern in `payroll-deficit-explorer`, `salt-cap-ny17`, `child-poverty-impact-dashboard`, etc.
- Loads via `next/script` with `strategy="afterInteractive"` in the root layout.
- Includes the standard engagement events (scroll depth, time-on-tool, outbound clicks) so PolicyBench shows up in the CRM tools leaderboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)