### PR TITLE
Fix mid-scroll header glitch and refresh the hero snapshot label

### DIFF
--- a/app/src/components/Hero.tsx
+++ b/app/src/components/Hero.tsx
@@ -1,7 +1,7 @@
 import type { BenchData, CountryCode } from "../types";
 import SiteHeader, { type HeaderNavItem } from "./SiteHeader";
 
-const SNAPSHOT_DATE_LABEL = "Snapshot 2026-06-14";
+const SNAPSHOT_DATE_LABEL = "Snapshot 2026-07-01";
 
 export default function Hero({
   selectedView,

--- a/app/src/components/SiteHeader.tsx
+++ b/app/src/components/SiteHeader.tsx
@@ -17,7 +17,12 @@ export type HeaderActionLink = {
 
 const HEADER_BACKGROUND_REVEAL_START = 0;
 const HEADER_BACKGROUND_REVEAL_DISTANCE = 160;
-const COMPACT_HEADER_REVEAL_START = 280;
+// Start the compact brand/nav reveal the moment the background finishes, not
+// 120px later. The old 280px start left a fully frosted bar holding nothing
+// but the right-side pills while hero text slid clipped beneath its border —
+// the mid-scroll "glitch" of #44. The hero title's bottom passes under the
+// bar by ~160px of scroll, so revealing here cannot double the brand.
+const COMPACT_HEADER_REVEAL_START = 160;
 const COMPACT_HEADER_REVEAL_DISTANCE = 72;
 
 function ViewSelector({


### PR DESCRIPTION
Fixes #44.

The sticky header's background frosted in over the first 160px of scroll, but the compact brand/nav waited until 280–352px. Through that 120px+ band the header was a fully opaque empty bar with two orphaned right-side pills, while hero text slid clipped beneath its border — the glitch in the issue screenshot's successor state (the original text-overlap died with the earlier `expandedContent` refactor; this was the residue).

The fix starts the compact-content reveal exactly where the background finishes (160px, same 72px fade). The hero title's bottom passes under the bar by ~160px of scroll, so the compact brand can't visibly double it. Verified in the dev preview at 0/140/200/260px offsets: hero text now dissolves under the frost and the bar assembles as one unit, `/paper` (always-expanded header) unaffected, mobile unaffected (opacity is forced to 1 there).

Also bumps the homepage hero's snapshot label to `Snapshot 2026-07-01`, matching the published dashboard-data-20260701 artifact that added Claude Fable 5. The `/paper` page keeps its frozen 2026-06-14 manuscript label by design.

`bun run lint`, `bun test tests` (58 pass), and `bun run build` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)