### PR TITLE
Add batch-API eval mode (Anthropic, OpenAI, Gemini)

### DIFF
--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -161,6 +161,32 @@ Provider transport, timeout, rate-limit, server, authentication, and
 request-configuration errors are infrastructure failures; chunks containing
 those errors remain incomplete and should be retried or rerun.
 
+## 4b. Batch Mode (Anthropic, OpenAI, Gemini)
+
+`eval-no-tools-batch` runs the same evaluation through the provider's batch
+API at ~50% of synchronous prices, with the provider handling parallelism.
+Request bodies are identical to sync mode; results land in the same
+`by_model/<model>.csv` schema, so retries, export, and the runstore work
+unchanged. xAI and DeepSeek have no batch APIs — keep using the chunked
+runner for them.
+
+```bash
+uv run policybench eval-no-tools-batch \
+  --country us \
+  --scenario-manifest "$RUN_DIR/us/scenarios.csv" \
+  --output-dir "$RUN_DIR/us" \
+  --model claude-fable-5 --model claude-sonnet-5 \
+  --poll-seconds 30
+```
+
+Batch ids persist under `$RUN_DIR/us/batches/`; rerunning the command
+resumes polling instead of resubmitting. Contract violations are re-requested
+in bounded repair rounds as follow-up batches. Two reporting differences,
+both deliberate: latency columns are left empty (batch round-trips include
+provider queue time, which is not model latency), and cost columns are
+reconstructed at standard synchronous rates so the leaderboard basis stays
+comparable while actual spend is roughly half.
+
 ## 5. Retry Broken Full Responses
 
 Before freezing a paid run, run bounded full-response retries for households

--- a/policybench/batch_eval.py
+++ b/policybench/batch_eval.py
@@ -1,0 +1,848 @@
+"""Batch-API evaluation: identical requests to the sync path at ~50% cost.
+
+Anthropic, OpenAI, and Gemini expose async batch endpoints at half their
+synchronous prices. This module submits the same request bodies the sync
+harness builds (``eval_no_tools``), polls until the provider finishes, and
+writes the same chunk CSVs the chunked runner produces — so resume, retries,
+merging, scoring, the runstore, and the dashboard export all work unchanged.
+
+Semantics that differ from sync mode, by design:
+
+- ``elapsed_seconds`` / ``request_started_at`` / ``request_completed_at`` are
+  empty on batch rows: a batch round-trip includes provider queue time, which
+  is not model latency. Models evaluated in batch mode show no latency on the
+  leaderboard rather than a misleading one. Batch turnaround is recorded in
+  the run's ``batches/`` state files.
+- Cost columns are reconstructed from token usage at standard synchronous
+  rates (litellm's price map plus ``PRICE_OVERRIDES_PER_1M``), matching the
+  leaderboard's comparison basis. Actual spend is ~half of the reported
+  figure; the state file records that the run used the batch endpoint.
+
+xAI and DeepSeek have no batch APIs; use the sync chunked runner for them.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Iterable, Iterator, Protocol
+
+import pandas as pd
+
+from policybench.config import PRICE_OVERRIDES_PER_1M
+from policybench.eval_no_tools import (
+    MAX_REPAIR_ROUNDS,
+    _chat_completion_request_kwargs,
+    _chunk_variables,
+    _enforce_explanation_value_contract,
+    _required_explanation_chunk_size,
+    _responses_request_kwargs,
+    _serialize_response_payload,
+    _uses_responses_api,
+    extract_explanations,
+    extract_predictions,
+)
+from policybench.scenarios import Scenario
+from policybench.spec import expand_programs_for_scenario
+
+BATCH_STATE_DIRNAME = "batches"
+DEFAULT_POLL_SECONDS = 30
+DEFAULT_MAX_WAIT_SECONDS = 4 * 60 * 60
+
+
+@dataclass
+class BatchUnit:
+    """One provider request: a scenario and the variable chunk it asks for."""
+
+    scenario_id: str
+    variables: list[str]
+    chunk_index: int
+    repair: bool = False
+
+    @property
+    def custom_id(self) -> str:
+        # Anthropic custom_ids allow [a-zA-Z0-9_-], max 64 chars. Variable
+        # names are too long to embed, so the state manifest carries the
+        # decode table and the id stays structural.
+        prefix = "r" if self.repair else "u"
+        return f"{self.scenario_id}__{prefix}{self.chunk_index:03d}"
+
+
+@dataclass
+class NormalizedResult:
+    """Provider-agnostic view of one batch result entry."""
+
+    custom_id: str
+    content: str | None = None
+    tool_calls: list | None = None
+    prompt_tokens: int | None = None
+    completion_tokens: int | None = None
+    reasoning_tokens: int | None = None
+    cached_prompt_tokens: int | None = None
+    provider_response_id: str | None = None
+    provider_resolved_model: str | None = None
+    error: str | None = None
+
+
+def _tool_call_shim(name: str, arguments: str):
+    """Minimal object with the attributes the sync extractors read."""
+    return SimpleNamespace(
+        function=SimpleNamespace(name=name, arguments=arguments),
+        id=None,
+        type="function",
+    )
+
+
+class BatchProviderAdapter(Protocol):
+    """One provider's batch endpoint behind a uniform surface."""
+
+    provider: str
+
+    def supports(self, model_id: str) -> bool: ...
+
+    def build_request_body(
+        self, scenario: Scenario, unit: BatchUnit, model_id: str
+    ) -> dict: ...
+
+    def submit(self, requests: list[tuple[str, dict]], model_id: str) -> str: ...
+
+    def status(self, batch_id: str) -> str:
+        """Return "in_progress", "ended", or "failed"."""
+        ...
+
+    def results(self, batch_id: str) -> Iterator[NormalizedResult]: ...
+
+
+class AnthropicBatchAdapter:
+    """Anthropic Message Batches (JSON request array, results as JSONL).
+
+    Request bodies are built from the sync path's OpenAI-format kwargs and
+    translated to Messages-API params, so a batch-run model sees the same
+    prompt, the same forced tool call, and the same token ceiling as a
+    sync-run one.
+    """
+
+    provider = "anthropic"
+
+    def __init__(self, client=None):
+        self._client = client
+
+    @property
+    def client(self):
+        if self._client is None:
+            import anthropic
+
+            self._client = anthropic.Anthropic()
+        return self._client
+
+    def supports(self, model_id: str) -> bool:
+        return model_id.startswith("claude-")
+
+    def build_request_body(
+        self, scenario: Scenario, unit: BatchUnit, model_id: str
+    ) -> dict:
+        _, kwargs = _chat_completion_request_kwargs(
+            scenario=scenario,
+            variables=unit.variables,
+            model_id=model_id,
+            repair=unit.repair,
+            include_explanations=True,
+        )
+        return _openai_kwargs_to_anthropic_params(kwargs)
+
+    def submit(self, requests: list[tuple[str, dict]], model_id: str) -> str:
+        batch = self.client.messages.batches.create(
+            requests=[
+                {"custom_id": custom_id, "params": params}
+                for custom_id, params in requests
+            ]
+        )
+        return batch.id
+
+    def status(self, batch_id: str) -> str:
+        batch = self.client.messages.batches.retrieve(batch_id)
+        if batch.processing_status == "ended":
+            return "ended"
+        if batch.processing_status in ("canceling", "canceled"):
+            return "failed"
+        return "in_progress"
+
+    def results(self, batch_id: str) -> Iterator[NormalizedResult]:
+        for entry in self.client.messages.batches.results(batch_id):
+            yield _normalize_anthropic_entry(entry)
+
+
+def _openai_kwargs_to_anthropic_params(kwargs: dict) -> dict:
+    """Translate the sync path's litellm kwargs into Messages-API params.
+
+    Only the shapes the no-tools harness produces are handled: a single user
+    message, one forced function tool, and a completion-token ceiling. A new
+    request feature must be added here and covered by the parity test before
+    batch runs may use it.
+    """
+    params: dict = {
+        "model": kwargs["model"],
+        "max_tokens": kwargs["max_completion_tokens"],
+        "messages": [
+            {"role": message["role"], "content": message["content"]}
+            for message in kwargs["messages"]
+        ],
+    }
+    tools = kwargs.get("tools") or []
+    if tools:
+        params["tools"] = [
+            {
+                "name": tool["function"]["name"],
+                "description": tool["function"].get("description", ""),
+                "input_schema": tool["function"]["parameters"],
+            }
+            for tool in tools
+        ]
+    tool_choice = kwargs.get("tool_choice")
+    if isinstance(tool_choice, dict) and tool_choice.get("type") == "function":
+        params["tool_choice"] = {
+            "type": "tool",
+            "name": tool_choice["function"]["name"],
+        }
+    unsupported = set(kwargs) - {
+        "model",
+        "messages",
+        "max_completion_tokens",
+        "tools",
+        "tool_choice",
+        "caching",
+        "timeout",
+    }
+    if unsupported:
+        raise ValueError(
+            "Sync request uses parameters the batch translation does not "
+            f"cover yet: {sorted(unsupported)}. Extend "
+            "_openai_kwargs_to_anthropic_params and its parity test."
+        )
+    return params
+
+
+def _normalize_anthropic_entry(entry) -> NormalizedResult:
+    result = entry.result
+    if result.type != "succeeded":
+        error = getattr(result, "error", None)
+        detail = getattr(error, "message", None) or getattr(error, "type", None)
+        return NormalizedResult(
+            custom_id=entry.custom_id,
+            error=f"batch_{result.type}: {detail or 'no detail'}",
+        )
+    message = result.message
+    text_parts: list[str] = []
+    tool_calls: list = []
+    for block in message.content:
+        block_type = getattr(block, "type", None)
+        if block_type == "text":
+            text_parts.append(block.text)
+        elif block_type == "tool_use":
+            tool_calls.append(_tool_call_shim(block.name, json.dumps(block.input)))
+    usage = message.usage
+    return NormalizedResult(
+        custom_id=entry.custom_id,
+        content="\n".join(text_parts) or None,
+        tool_calls=tool_calls or None,
+        prompt_tokens=getattr(usage, "input_tokens", None),
+        completion_tokens=getattr(usage, "output_tokens", None),
+        cached_prompt_tokens=getattr(usage, "cache_read_input_tokens", None),
+        provider_response_id=getattr(message, "id", None),
+        provider_resolved_model=getattr(message, "model", None),
+    )
+
+
+class OpenAIBatchAdapter:
+    """OpenAI Batch API over the responses endpoint the gpt-5.x path uses.
+
+    OpenAI batches take a JSONL file where each line carries a custom_id and
+    a raw request body for the target endpoint. The harness's gpt-5.x models
+    go through ``litellm.responses``, so bodies are built by the same
+    ``_responses_request_kwargs`` used sync.
+    """
+
+    provider = "openai"
+    endpoint = "/v1/responses"
+
+    def __init__(self, client=None):
+        self._client = client
+
+    @property
+    def client(self):
+        if self._client is None:
+            import openai
+
+            self._client = openai.OpenAI()
+        return self._client
+
+    def supports(self, model_id: str) -> bool:
+        return _uses_responses_api(model_id)
+
+    def build_request_body(
+        self, scenario: Scenario, unit: BatchUnit, model_id: str
+    ) -> dict:
+        _, kwargs = _responses_request_kwargs(
+            scenario=scenario,
+            variables=unit.variables,
+            model_id=model_id,
+            repair=unit.repair,
+            include_explanations=True,
+        )
+        kwargs.pop("timeout", None)
+        return kwargs
+
+    def submit(self, requests: list[tuple[str, dict]], model_id: str) -> str:
+        lines = "\n".join(
+            json.dumps(
+                {
+                    "custom_id": custom_id,
+                    "method": "POST",
+                    "url": self.endpoint,
+                    "body": body,
+                }
+            )
+            for custom_id, body in requests
+        )
+        batch_file = self.client.files.create(
+            file=("policybench_batch.jsonl", lines.encode("utf-8")),
+            purpose="batch",
+        )
+        batch = self.client.batches.create(
+            input_file_id=batch_file.id,
+            endpoint=self.endpoint,
+            completion_window="24h",
+        )
+        return batch.id
+
+    def status(self, batch_id: str) -> str:
+        batch = self.client.batches.retrieve(batch_id)
+        if batch.status == "completed":
+            return "ended"
+        if batch.status in ("failed", "expired", "cancelled", "cancelling"):
+            return "failed"
+        return "in_progress"
+
+    def results(self, batch_id: str) -> Iterator[NormalizedResult]:
+        batch = self.client.batches.retrieve(batch_id)
+        raw = self.client.files.content(batch.output_file_id).text
+        for line in raw.splitlines():
+            if line.strip():
+                yield _normalize_openai_entry(json.loads(line))
+
+
+def _normalize_openai_entry(entry: dict) -> NormalizedResult:
+    custom_id = entry.get("custom_id", "")
+    response = entry.get("response") or {}
+    if entry.get("error") or response.get("status_code", 200) >= 400:
+        detail = entry.get("error") or response.get("body")
+        return NormalizedResult(
+            custom_id=custom_id, error=f"batch_errored: {json.dumps(detail)[:200]}"
+        )
+    body = response.get("body") or {}
+    text_parts: list[str] = []
+    tool_calls: list = []
+    for item in body.get("output", []):
+        item_type = item.get("type")
+        if item_type == "message":
+            for part in item.get("content", []):
+                if part.get("type") == "output_text":
+                    text_parts.append(part.get("text", ""))
+        elif item_type == "function_call":
+            tool_calls.append(
+                _tool_call_shim(item.get("name", ""), item.get("arguments", "{}"))
+            )
+    usage = body.get("usage") or {}
+    details = usage.get("output_tokens_details") or {}
+    return NormalizedResult(
+        custom_id=custom_id,
+        content="\n".join(text_parts) or None,
+        tool_calls=tool_calls or None,
+        prompt_tokens=usage.get("input_tokens"),
+        completion_tokens=usage.get("output_tokens"),
+        reasoning_tokens=details.get("reasoning_tokens"),
+        provider_response_id=body.get("id"),
+        provider_resolved_model=body.get("model"),
+    )
+
+
+class GeminiBatchAdapter:
+    """Gemini developer-API inline batches via google-genai.
+
+    The harness's ``gemini/`` models use the developer API, whose batch mode
+    accepts inline requests (no GCS staging). Marked experimental until the
+    first paid gemini batch run validates it end to end (#85).
+    """
+
+    provider = "gemini"
+
+    def __init__(self, client=None):
+        self._client = client
+
+    @property
+    def client(self):
+        if self._client is None:
+            from google import genai
+
+            self._client = genai.Client()
+        return self._client
+
+    def supports(self, model_id: str) -> bool:
+        return model_id.startswith("gemini/")
+
+    def build_request_body(
+        self, scenario: Scenario, unit: BatchUnit, model_id: str
+    ) -> dict:
+        _, kwargs = _chat_completion_request_kwargs(
+            scenario=scenario,
+            variables=unit.variables,
+            model_id=model_id,
+            repair=unit.repair,
+            include_explanations=True,
+        )
+        prompt = kwargs["messages"][0]["content"]
+        return {
+            "contents": [{"role": "user", "parts": [{"text": prompt}]}],
+            "config": {
+                "max_output_tokens": kwargs["max_completion_tokens"],
+                "response_mime_type": "application/json",
+            },
+        }
+
+    def submit(self, requests: list[tuple[str, dict]], model_id: str) -> str:
+        model = model_id.split("/", 1)[1]
+        job = self.client.batches.create(
+            model=model,
+            src=[
+                {**body, "metadata": {"custom_id": custom_id}}
+                for custom_id, body in requests
+            ],
+        )
+        return job.name
+
+    def status(self, batch_id: str) -> str:
+        job = self.client.batches.get(name=batch_id)
+        state = str(getattr(job, "state", ""))
+        if "SUCCEEDED" in state:
+            return "ended"
+        if any(word in state for word in ("FAILED", "CANCELLED", "EXPIRED")):
+            return "failed"
+        return "in_progress"
+
+    def results(self, batch_id: str) -> Iterator[NormalizedResult]:
+        job = self.client.batches.get(name=batch_id)
+        for inline in job.dest.inlined_responses:
+            metadata = getattr(inline, "metadata", None) or {}
+            custom_id = metadata.get("custom_id", "")
+            if getattr(inline, "error", None):
+                yield NormalizedResult(
+                    custom_id=custom_id,
+                    error=f"batch_errored: {inline.error}",
+                )
+                continue
+            response = inline.response
+            text = getattr(response, "text", None)
+            usage = getattr(response, "usage_metadata", None)
+            yield NormalizedResult(
+                custom_id=custom_id,
+                content=text,
+                prompt_tokens=getattr(usage, "prompt_token_count", None),
+                completion_tokens=getattr(usage, "candidates_token_count", None),
+                reasoning_tokens=getattr(usage, "thoughts_token_count", None),
+                provider_resolved_model=getattr(response, "model_version", None),
+            )
+
+
+ADAPTERS: tuple[type, ...] = (
+    AnthropicBatchAdapter,
+    OpenAIBatchAdapter,
+    GeminiBatchAdapter,
+)
+
+
+def adapter_for_model(model_id: str, adapters: Iterable | None = None):
+    """Return the adapter that owns ``model_id``, or None (sync-only model)."""
+    candidates = list(adapters) if adapters is not None else [a() for a in ADAPTERS]
+    for adapter in candidates:
+        if adapter.supports(model_id):
+            return adapter
+    return None
+
+
+def _standard_rate(model_name: str, model_id: str) -> tuple[float, float] | None:
+    """Per-token USD (input, output) at standard synchronous rates."""
+    import litellm
+
+    entry = litellm.model_cost.get(model_id) or litellm.model_cost.get(
+        model_id.split("/")[-1]
+    )
+    if entry and entry.get("input_cost_per_token"):
+        return entry["input_cost_per_token"], entry["output_cost_per_token"]
+    override = PRICE_OVERRIDES_PER_1M.get(model_name)
+    if override:
+        return override["input"] / 1e6, override["output"] / 1e6
+    return None
+
+
+@dataclass
+class BatchRunState:
+    """Persisted per-round record so interrupted runs re-poll, not resubmit."""
+
+    model: str
+    round_index: int
+    batch_id: str
+    provider: str
+    submitted_at: float
+    units: dict[str, dict] = field(default_factory=dict)
+    completed_at: float | None = None
+
+    def path(self, run_dir: Path) -> Path:
+        return (
+            run_dir / BATCH_STATE_DIRNAME / f"{self.model}.round{self.round_index}.json"
+        )
+
+    def save(self, run_dir: Path) -> None:
+        path = self.path(run_dir)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(self.__dict__, indent=2), encoding="utf-8")
+
+    @classmethod
+    def load(cls, run_dir: Path, model: str, round_index: int):
+        path = run_dir / BATCH_STATE_DIRNAME / f"{model}.round{round_index}.json"
+        if not path.exists():
+            return None
+        return cls(**json.loads(path.read_text(encoding="utf-8")))
+
+
+def build_units(
+    scenarios: list[Scenario],
+    programs: list[str],
+    model_id: str,
+    completed_keys: set[tuple[str, str]] | None = None,
+) -> list[BatchUnit]:
+    """Expand scenarios into per-request units, mirroring sync chunking."""
+    completed = completed_keys or set()
+    chunk_size = _required_explanation_chunk_size(model_id, True)
+    units: list[BatchUnit] = []
+    for scenario in scenarios:
+        expanded = expand_programs_for_scenario(programs, scenario)
+        chunks = _chunk_variables(expanded, chunk_size) if chunk_size else [expanded]
+        for index, chunk in enumerate(chunks):
+            if all((scenario.id, variable) in completed for variable in chunk):
+                continue
+            units.append(
+                BatchUnit(scenario_id=scenario.id, variables=chunk, chunk_index=index)
+            )
+    return units
+
+
+def parse_unit_result(
+    unit: BatchUnit, result: NormalizedResult
+) -> tuple[dict, dict, str | None, str | None]:
+    """Run the sync extractors over a normalized result.
+
+    Returns (predictions, explanations, raw_response, error).
+    """
+    if result.error:
+        empty = {variable: None for variable in unit.variables}
+        return empty, dict(empty), None, result.error
+    raw_response = _serialize_response_payload(
+        content=result.content,
+        tool_calls=result.tool_calls,
+        function_call=None,
+    )
+    predictions = extract_predictions(
+        content=result.content,
+        variables=unit.variables,
+        tool_calls=result.tool_calls,
+        function_call=None,
+    )
+    explanations = extract_explanations(
+        content=result.content,
+        variables=unit.variables,
+        tool_calls=result.tool_calls,
+        function_call=None,
+    )
+    predictions, explanations = _enforce_explanation_value_contract(
+        predictions, explanations, unit.variables
+    )
+    return predictions, explanations, raw_response, None
+
+
+def rows_from_unit(
+    *,
+    model_name: str,
+    model_id: str,
+    unit: BatchUnit,
+    predictions: dict,
+    explanations: dict,
+    raw_response: str | None,
+    error: str | None,
+    result: NormalizedResult | None,
+    run_id: str | None = None,
+) -> list[dict]:
+    """Emit CSV rows in the sync schema, usage apportioned across the chunk."""
+    size = len(unit.variables)
+    rate = _standard_rate(model_name, model_id)
+    prompt_tokens = result.prompt_tokens if result else None
+    completion_tokens = result.completion_tokens if result else None
+    reconstructed = None
+    if rate and prompt_tokens is not None and completion_tokens is not None:
+        reconstructed = prompt_tokens * rate[0] + completion_tokens * rate[1]
+    total_tokens = (
+        prompt_tokens + completion_tokens
+        if prompt_tokens is not None and completion_tokens is not None
+        else None
+    )
+
+    def split(value):
+        return value / size if value is not None else None
+
+    call_id = ":".join(
+        part for part in [run_id, model_name, unit.scenario_id] if part is not None
+    )
+    rows = []
+    for variable in unit.variables:
+        rows.append(
+            {
+                **({"run_id": run_id} if run_id is not None else {}),
+                "call_id": call_id,
+                "model": model_name,
+                "scenario_id": unit.scenario_id,
+                "variable": variable,
+                "prediction": predictions.get(variable),
+                "explanation": explanations.get(variable),
+                "raw_response": raw_response,
+                "error": error,
+                # Batch round-trips include provider queue time, which is not
+                # model latency; leave the latency fields empty rather than
+                # publish a misleading number.
+                "elapsed_seconds": None,
+                "request_started_at": None,
+                "request_completed_at": None,
+                "prompt_tokens": split(prompt_tokens),
+                "completion_tokens": split(completion_tokens),
+                "total_tokens": split(total_tokens),
+                "reasoning_tokens": split(result.reasoning_tokens if result else None),
+                "cached_prompt_tokens": split(
+                    result.cached_prompt_tokens if result else None
+                ),
+                "provider_reported_cost_usd": None,
+                "reconstructed_cost_usd": split(reconstructed),
+                "total_cost_usd": split(reconstructed),
+                "cost_is_estimated": False if reconstructed is not None else None,
+                "estimated_cost_usd": split(reconstructed),
+                "provider_response_id": result.provider_response_id if result else None,
+                "provider_system_fingerprint": None,
+                "provider_resolved_model": (
+                    result.provider_resolved_model if result else None
+                ),
+            }
+        )
+    return rows
+
+
+def run_batch_eval(
+    *,
+    scenarios: list[Scenario],
+    programs: list[str],
+    model_name: str,
+    model_id: str,
+    run_dir: Path,
+    adapter=None,
+    poll_seconds: int = DEFAULT_POLL_SECONDS,
+    max_wait_seconds: int = DEFAULT_MAX_WAIT_SECONDS,
+    sleep=time.sleep,
+    clock=time.time,
+    log=print,
+) -> pd.DataFrame:
+    """Submit, poll, collect, and repair one model's run via its batch API.
+
+    Writes ``<run_dir>/by_model/<model>.csv`` in the sync schema and returns
+    the frame. Rounds beyond the first re-request only units whose response
+    violated the answer contract, mirroring the sync repair loop.
+    """
+    adapter = adapter or adapter_for_model(model_id)
+    if adapter is None:
+        raise ValueError(
+            f"{model_id} has no batch adapter (xAI and DeepSeek have no batch "
+            "APIs) — use the sync chunked runner."
+        )
+
+    scenario_by_id = {scenario.id: scenario for scenario in scenarios}
+    rows_by_key: dict[tuple[str, str], dict] = {}
+    units = build_units(scenarios, programs, model_id)
+
+    for round_index in range(1 + MAX_REPAIR_ROUNDS):
+        if not units:
+            break
+        state = BatchRunState.load(run_dir, model_name, round_index)
+        if state is None:
+            repair = round_index > 0
+            for unit in units:
+                unit.repair = repair
+            requests = [
+                (
+                    unit.custom_id,
+                    adapter.build_request_body(
+                        scenario_by_id[unit.scenario_id], unit, model_id
+                    ),
+                )
+                for unit in units
+            ]
+            log(
+                f"[{model_name}] round {round_index}: submitting "
+                f"{len(requests)} requests via {adapter.provider} batch"
+            )
+            batch_id = adapter.submit(requests, model_id)
+            state = BatchRunState(
+                model=model_name,
+                round_index=round_index,
+                batch_id=batch_id,
+                provider=adapter.provider,
+                submitted_at=clock(),
+                units={
+                    unit.custom_id: {
+                        "scenario_id": unit.scenario_id,
+                        "variables": unit.variables,
+                        "chunk_index": unit.chunk_index,
+                        "repair": unit.repair,
+                    }
+                    for unit in units
+                },
+            )
+            state.save(run_dir)
+        else:
+            log(f"[{model_name}] round {round_index}: resuming batch {state.batch_id}")
+
+        deadline = clock() + max_wait_seconds
+        while True:
+            status = adapter.status(state.batch_id)
+            if status == "ended":
+                break
+            if status == "failed":
+                raise RuntimeError(
+                    f"Batch {state.batch_id} for {model_name} ended as failed"
+                )
+            if clock() > deadline:
+                raise TimeoutError(
+                    f"Batch {state.batch_id} for {model_name} still running "
+                    f"after {max_wait_seconds}s; rerun to resume polling"
+                )
+            sleep(poll_seconds)
+
+        unit_index = {
+            custom_id: BatchUnit(
+                scenario_id=meta["scenario_id"],
+                variables=list(meta["variables"]),
+                chunk_index=meta["chunk_index"],
+                repair=meta.get("repair", False),
+            )
+            for custom_id, meta in state.units.items()
+        }
+        seen: set[str] = set()
+        for result in adapter.results(state.batch_id):
+            unit = unit_index.get(result.custom_id)
+            if unit is None:
+                continue
+            seen.add(result.custom_id)
+            predictions, explanations, raw_response, error = parse_unit_result(
+                unit, result
+            )
+            for row in rows_from_unit(
+                model_name=model_name,
+                model_id=model_id,
+                unit=unit,
+                predictions=predictions,
+                explanations=explanations,
+                raw_response=raw_response,
+                error=error,
+                result=result if not result.error else None,
+            ):
+                key = (row["scenario_id"], row["variable"])
+                existing = rows_by_key.get(key)
+                # Later rounds only override rows the earlier round left
+                # broken, mirroring sync repair-merge semantics.
+                if (
+                    existing is None
+                    or existing.get("prediction") is None
+                    or not str(existing.get("explanation") or "").strip()
+                ):
+                    rows_by_key[key] = row
+        for custom_id, unit in unit_index.items():
+            if custom_id in seen:
+                continue
+            for row in rows_from_unit(
+                model_name=model_name,
+                model_id=model_id,
+                unit=unit,
+                predictions={variable: None for variable in unit.variables},
+                explanations={variable: None for variable in unit.variables},
+                raw_response=None,
+                error="batch_missing: no result entry returned",
+                result=None,
+            ):
+                rows_by_key.setdefault((row["scenario_id"], row["variable"]), row)
+
+        state.completed_at = clock()
+        state.save(run_dir)
+        log(
+            f"[{model_name}] round {round_index}: collected "
+            f"{len(seen)}/{len(unit_index)} results in "
+            f"{state.completed_at - state.submitted_at:.0f}s"
+        )
+
+        units = _repair_targets(scenario_by_id, programs, model_id, rows_by_key)
+        if units:
+            log(
+                f"[{model_name}] round {round_index}: {len(units)} units "
+                "violate the answer contract; scheduling repair round"
+            )
+
+    frame = pd.DataFrame(list(rows_by_key.values()))
+    by_model = run_dir / "by_model"
+    by_model.mkdir(parents=True, exist_ok=True)
+    output = by_model / f"{model_name}.csv"
+    frame.to_csv(output, index=False)
+    log(f"[{model_name}] wrote {output} ({len(frame):,} rows)")
+    return frame
+
+
+def _repair_targets(
+    scenario_by_id: dict,
+    programs: list[str],
+    model_id: str,
+    rows_by_key: dict[tuple[str, str], dict],
+) -> list[BatchUnit]:
+    """Units whose rows are missing a parsed value or a nonempty explanation."""
+    broken: dict[str, list[str]] = {}
+    for (scenario_id, variable), row in rows_by_key.items():
+        if (
+            row.get("prediction") is None
+            or not str(row.get("explanation") or "").strip()
+        ):
+            broken.setdefault(scenario_id, []).append(variable)
+    chunk_size = _required_explanation_chunk_size(model_id, True)
+    units: list[BatchUnit] = []
+    for scenario_id, variables in sorted(broken.items()):
+        ordered = [
+            variable
+            for variable in expand_programs_for_scenario(
+                programs, scenario_by_id[scenario_id]
+            )
+            if variable in set(variables)
+        ]
+        chunks = _chunk_variables(ordered, chunk_size) if chunk_size else [ordered]
+        for index, chunk in enumerate(chunks):
+            units.append(
+                BatchUnit(
+                    scenario_id=scenario_id,
+                    variables=chunk,
+                    chunk_index=index,
+                    repair=True,
+                )
+            )
+    return units

--- a/policybench/cli.py
+++ b/policybench/cli.py
@@ -453,6 +453,56 @@ def main():
         ),
     )
 
+    batch_parser = subparsers.add_parser(
+        "eval-no-tools-batch",
+        help=(
+            "Run AI-alone evaluation through the provider's batch API "
+            "(~50%% of sync cost; Anthropic, OpenAI, and Gemini models)"
+        ),
+    )
+    batch_parser.add_argument(
+        "-s",
+        "--scenario-manifest",
+        required=True,
+        help="CSV file with serialized scenarios exported by `reference-outputs`",
+    )
+    batch_parser.add_argument(
+        "-o",
+        "--output-dir",
+        required=True,
+        help="Run directory; writes by_model/<model>.csv and batches/ state",
+    )
+    batch_parser.add_argument(
+        "--country",
+        choices=sorted(COUNTRY_PROGRAMS),
+        required=True,
+        help="Benchmark country to evaluate",
+    )
+    batch_parser.add_argument(
+        "--model",
+        action="append",
+        dest="models",
+        required=True,
+        help="Configured model name to evaluate. Repeat for several models.",
+    )
+    batch_parser.add_argument(
+        "--program-set",
+        default=DEFAULT_PROGRAM_SET,
+        help="Benchmark output set to use. Defaults to headline.",
+    )
+    batch_parser.add_argument(
+        "--poll-seconds",
+        type=int,
+        default=30,
+        help="Seconds between batch status polls",
+    )
+    batch_parser.add_argument(
+        "--max-wait-seconds",
+        type=int,
+        default=4 * 60 * 60,
+        help="Give up polling one batch after this long (rerun resumes it)",
+    )
+
     # Export full run
     export_parser = subparsers.add_parser(
         "export-full-run",
@@ -1004,6 +1054,34 @@ def main():
         except (FileNotFoundError, RuntimeError, ValueError) as exc:
             raise SystemExit(str(exc)) from exc
         print(f"Chunked no-tools predictions saved to {output}")
+
+    elif args.command == "eval-no-tools-batch":
+        from policybench.batch_eval import adapter_for_model, run_batch_eval
+        from policybench.scenarios import load_scenarios_from_manifest
+
+        scenarios = load_scenarios_from_manifest(args.scenario_manifest)
+        programs = get_programs(args.country, args.program_set)
+        models = _parse_models(args.models)
+        run_dir = Path(args.output_dir)
+        for model_name, model_id in models.items():
+            if adapter_for_model(model_id) is None:
+                raise SystemExit(
+                    f"{model_name} ({model_id}) has no batch API — run it "
+                    "with eval-no-tools-chunked instead."
+                )
+        for model_name, model_id in models.items():
+            try:
+                run_batch_eval(
+                    scenarios=scenarios,
+                    programs=programs,
+                    model_name=model_name,
+                    model_id=model_id,
+                    run_dir=run_dir,
+                    poll_seconds=args.poll_seconds,
+                    max_wait_seconds=args.max_wait_seconds,
+                )
+            except (RuntimeError, TimeoutError, ValueError) as exc:
+                raise SystemExit(str(exc)) from exc
 
     elif args.command == "export-full-run":
         from policybench.full_run_export import export_full_run

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,8 @@ dependencies = [
     "numpy>=1.24",
     "policyengine[us]==4.16.1",
     "policyengine-uk==2.89.0",
+    "anthropic>=0.115.1",
+    "google-genai>=2.10.0",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_batch_eval.py
+++ b/tests/test_batch_eval.py
@@ -1,0 +1,426 @@
+"""Batch-mode eval: request parity, result normalization, repair, resume."""
+
+import json
+from types import SimpleNamespace
+
+import pandas as pd
+import pytest
+
+from policybench.batch_eval import (
+    AnthropicBatchAdapter,
+    BatchRunState,
+    BatchUnit,
+    NormalizedResult,
+    _normalize_anthropic_entry,
+    _normalize_openai_entry,
+    _openai_kwargs_to_anthropic_params,
+    adapter_for_model,
+    build_units,
+    parse_unit_result,
+    rows_from_unit,
+    run_batch_eval,
+)
+from policybench.eval_no_tools import _chat_completion_request_kwargs
+from policybench.scenarios import Person, Scenario
+from policybench.spec import expand_programs_for_scenario
+
+
+@pytest.fixture
+def scenario():
+    return Scenario(
+        id="scenario_000",
+        state="CA",
+        filing_status="single",
+        adults=[Person(name="adult1", age=35, employment_income=50_000.0)],
+        year=2026,
+    )
+
+
+@pytest.fixture
+def second_scenario():
+    return Scenario(
+        id="scenario_001",
+        state="TX",
+        filing_status="single",
+        adults=[Person(name="adult1", age=40, employment_income=30_000.0)],
+        year=2026,
+    )
+
+
+def test_anthropic_request_translation_matches_sync_shape(scenario):
+    """The batch body must carry the same prompt, forced tool, and token
+    ceiling the sync path sends, in Messages-API form."""
+    _, kwargs = _chat_completion_request_kwargs(
+        scenario=scenario,
+        variables=["eitc"],
+        model_id="claude-sonnet-5",
+        repair=False,
+        include_explanations=True,
+    )
+    params = _openai_kwargs_to_anthropic_params(kwargs)
+
+    assert params["model"] == "claude-sonnet-5"
+    assert params["max_tokens"] == 16384
+    assert [message["role"] for message in params["messages"]] == ["user"]
+    assert params["messages"][0]["content"] == kwargs["messages"][0]["content"]
+    (tool,) = params["tools"]
+    assert tool["name"] == "submit_outputs"
+    outputs_schema = tool["input_schema"]["properties"]["outputs"]
+    assert outputs_schema["properties"]["eitc"]["required"] == [
+        "value",
+        "explanation",
+    ]
+    assert params["tool_choice"] == {"type": "tool", "name": "submit_outputs"}
+
+
+def test_anthropic_translation_rejects_unknown_parameters():
+    """A new sync request feature must be translated deliberately, not
+    silently dropped from batch requests."""
+    with pytest.raises(ValueError, match="response_format"):
+        _openai_kwargs_to_anthropic_params(
+            {
+                "model": "claude-sonnet-5",
+                "messages": [{"role": "user", "content": "hi"}],
+                "max_completion_tokens": 100,
+                "response_format": {"type": "json_object"},
+            }
+        )
+
+
+def test_adapter_routing():
+    assert isinstance(adapter_for_model("claude-fable-5"), AnthropicBatchAdapter)
+    assert adapter_for_model("gpt-5.5").provider == "openai"
+    assert adapter_for_model("gemini/gemini-3.5-flash").provider == "gemini"
+    assert adapter_for_model("xai/grok-4.3") is None
+    assert adapter_for_model("deepseek/deepseek-v4-pro") is None
+
+
+def test_build_units_mirrors_sync_chunking(scenario):
+    programs = ["eitc", "snap", "medicaid_eligible"]
+    units = build_units([scenario], programs, "claude-sonnet-5")
+    expanded = expand_programs_for_scenario(programs, scenario)
+    # Claude explanation runs chunk one output per request.
+    assert [unit.variables for unit in units] == [[v] for v in expanded]
+    assert all(len(unit.custom_id) <= 64 for unit in units)
+    assert all(c.isalnum() or c in "_-" for unit in units for c in unit.custom_id)
+    # Completed keys are skipped.
+    done = {(scenario.id, expanded[0])}
+    remaining = build_units([scenario], programs, "claude-sonnet-5", done)
+    assert len(remaining) == len(units) - 1
+
+
+def test_normalize_anthropic_entry_success_and_error():
+    entry = SimpleNamespace(
+        custom_id="scenario_000__u000",
+        result=SimpleNamespace(
+            type="succeeded",
+            message=SimpleNamespace(
+                id="msg_01",
+                model="claude-sonnet-5",
+                content=[
+                    SimpleNamespace(type="text", text="working"),
+                    SimpleNamespace(
+                        type="tool_use",
+                        name="submit_outputs",
+                        input={
+                            "outputs": {"eitc": {"value": 4022.0, "explanation": "ok"}}
+                        },
+                    ),
+                ],
+                usage=SimpleNamespace(
+                    input_tokens=100,
+                    output_tokens=50,
+                    cache_read_input_tokens=0,
+                ),
+            ),
+        ),
+    )
+    normalized = _normalize_anthropic_entry(entry)
+    assert normalized.prompt_tokens == 100
+    assert normalized.tool_calls[0].function.name == "submit_outputs"
+    assert json.loads(normalized.tool_calls[0].function.arguments) == {
+        "outputs": {"eitc": {"value": 4022.0, "explanation": "ok"}}
+    }
+
+    errored = SimpleNamespace(
+        custom_id="scenario_000__u001",
+        result=SimpleNamespace(
+            type="errored", error=SimpleNamespace(type="rate_limit", message="slow")
+        ),
+    )
+    assert "rate_limit" in _normalize_anthropic_entry(errored).error or (
+        "slow" in _normalize_anthropic_entry(errored).error
+    )
+
+
+def test_normalize_openai_entry_responses_shape():
+    entry = {
+        "custom_id": "scenario_000__u000",
+        "response": {
+            "status_code": 200,
+            "body": {
+                "id": "resp_01",
+                "model": "gpt-5.5",
+                "output": [
+                    {
+                        "type": "function_call",
+                        "name": "submit_outputs",
+                        "arguments": json.dumps(
+                            {"eitc": {"value": 1.0, "explanation": "x"}}
+                        ),
+                    }
+                ],
+                "usage": {
+                    "input_tokens": 10,
+                    "output_tokens": 5,
+                    "output_tokens_details": {"reasoning_tokens": 2},
+                },
+            },
+        },
+    }
+    normalized = _normalize_openai_entry(entry)
+    assert normalized.reasoning_tokens == 2
+    assert normalized.tool_calls[0].function.name == "submit_outputs"
+
+
+def test_parse_unit_result_roundtrip(scenario):
+    unit = BatchUnit(scenario_id=scenario.id, variables=["eitc"], chunk_index=0)
+    result = NormalizedResult(
+        custom_id=unit.custom_id,
+        tool_calls=[
+            SimpleNamespace(
+                function=SimpleNamespace(
+                    name="submit_outputs",
+                    arguments=json.dumps(
+                        {
+                            "outputs": {
+                                "eitc": {
+                                    "value": 4022.0,
+                                    "explanation": "34% of earned. value = 4022",
+                                }
+                            }
+                        }
+                    ),
+                )
+            )
+        ],
+    )
+    predictions, explanations, raw, error = parse_unit_result(unit, result)
+    assert error is None
+    assert predictions == {"eitc": 4022.0}
+    assert explanations["eitc"] == "34% of earned. value = 4022"
+    assert "submit_outputs" in raw
+
+
+def test_rows_apportion_usage_and_omit_latency():
+    unit = BatchUnit(
+        scenario_id="scenario_000",
+        variables=["eitc", "snap", "ssi"],
+        chunk_index=0,
+    )
+    result = NormalizedResult(
+        custom_id=unit.custom_id, prompt_tokens=300, completion_tokens=30
+    )
+    rows = rows_from_unit(
+        model_name="gpt-5.5",
+        model_id="gpt-5.5",
+        unit=unit,
+        predictions={"eitc": 1.0, "snap": 2.0, "ssi": 3.0},
+        explanations={"eitc": "a", "snap": "b", "ssi": "c"},
+        raw_response="{}",
+        error=None,
+        result=result,
+    )
+    assert len(rows) == 3
+    assert all(row["prompt_tokens"] == 100 for row in rows)
+    assert all(row["elapsed_seconds"] is None for row in rows)
+    assert all(row["request_started_at"] is None for row in rows)
+    # Cost reconstructed at standard sync rates for leaderboard parity.
+    assert rows[0]["reconstructed_cost_usd"] is not None
+    assert rows[0]["total_cost_usd"] == rows[0]["reconstructed_cost_usd"]
+
+
+class FakeAdapter:
+    """Scripted adapter: first round breaks one unit, repair round fixes it."""
+
+    provider = "fake"
+
+    def __init__(self):
+        self.submissions: list[list[tuple[str, dict]]] = []
+        self.status_calls = 0
+
+    def supports(self, model_id: str) -> bool:
+        return True
+
+    def build_request_body(self, scenario, unit, model_id):
+        return {"scenario": scenario.id, "variables": unit.variables}
+
+    def submit(self, requests, model_id):
+        self.submissions.append(requests)
+        return f"batch_{len(self.submissions)}"
+
+    def status(self, batch_id):
+        self.status_calls += 1
+        return "ended"
+
+    def results(self, batch_id):
+        round_index = int(batch_id.split("_")[1]) - 1
+        for custom_id, body in self.submissions[round_index]:
+            variables = body["variables"]
+            good = {
+                "outputs": {
+                    variable: {
+                        "value": 1000.0,
+                        "explanation": f"repaired {variable}. value = 1000",
+                    }
+                    for variable in variables
+                }
+            }
+            if round_index == 0 and custom_id.endswith("u001"):
+                # Missing explanation -> violates the contract -> repair target.
+                yield NormalizedResult(
+                    custom_id=custom_id,
+                    tool_calls=[
+                        SimpleNamespace(
+                            function=SimpleNamespace(
+                                name="submit_outputs",
+                                arguments=json.dumps(
+                                    {
+                                        "outputs": {
+                                            variable: {
+                                                "value": 7.0,
+                                                "explanation": "",
+                                            }
+                                            for variable in variables
+                                        }
+                                    }
+                                ),
+                            )
+                        )
+                    ],
+                    prompt_tokens=10,
+                    completion_tokens=5,
+                )
+                continue
+            yield NormalizedResult(
+                custom_id=custom_id,
+                tool_calls=[
+                    SimpleNamespace(
+                        function=SimpleNamespace(
+                            name="submit_outputs", arguments=json.dumps(good)
+                        )
+                    )
+                ],
+                prompt_tokens=10,
+                completion_tokens=5,
+            )
+
+
+def test_run_batch_eval_end_to_end_with_repair(tmp_path, scenario, second_scenario):
+    adapter = FakeAdapter()
+    frame = run_batch_eval(
+        scenarios=[scenario, second_scenario],
+        programs=["eitc", "snap"],
+        model_name="claude-sonnet-5",
+        model_id="claude-sonnet-5",
+        run_dir=tmp_path,
+        adapter=adapter,
+        poll_seconds=0,
+        sleep=lambda _s: None,
+        log=lambda *_a, **_k: None,
+    )
+
+    expanded = expand_programs_for_scenario(["eitc", "snap"], scenario)
+    assert len(frame) == 2 * len(expanded)
+    # Every row satisfies the answer contract after the repair round.
+    assert frame["prediction"].notna().all()
+    assert frame["explanation"].astype(str).str.strip().ne("").all()
+    # The broken unit was re-requested in a second, smaller submission.
+    assert len(adapter.submissions) == 2
+    assert len(adapter.submissions[1]) == 2  # one broken unit per scenario
+    # Chunk-of-one repair carries the repaired explanation.
+    repaired = frame[frame["explanation"].astype(str).str.startswith("repaired")]
+    assert len(repaired) == len(frame)  # round 2 rows only replace broken ones
+    # State files persisted for both rounds.
+    assert (tmp_path / "batches" / "claude-sonnet-5.round0.json").exists()
+    assert (tmp_path / "batches" / "claude-sonnet-5.round1.json").exists()
+    assert (tmp_path / "by_model" / "claude-sonnet-5.csv").exists()
+    written = pd.read_csv(tmp_path / "by_model" / "claude-sonnet-5.csv")
+    assert set(written.columns) >= {
+        "call_id",
+        "model",
+        "scenario_id",
+        "variable",
+        "prediction",
+        "explanation",
+        "raw_response",
+        "error",
+        "elapsed_seconds",
+        "request_started_at",
+        "request_completed_at",
+        "prompt_tokens",
+        "completion_tokens",
+        "total_tokens",
+        "reasoning_tokens",
+        "cached_prompt_tokens",
+        "provider_reported_cost_usd",
+        "reconstructed_cost_usd",
+        "total_cost_usd",
+        "cost_is_estimated",
+        "estimated_cost_usd",
+        "provider_response_id",
+        "provider_system_fingerprint",
+        "provider_resolved_model",
+    }
+
+
+class ResumeAdapter(FakeAdapter):
+    """Round 0 already submitted by a prior process; results retrievable."""
+
+    def __init__(self, prior_requests):
+        super().__init__()
+        self.submissions = [prior_requests]
+
+    def submit(self, requests, model_id):
+        self.submissions.append(requests)
+        return f"batch_{len(self.submissions)}"
+
+
+def test_run_batch_eval_resumes_existing_round_without_resubmitting(tmp_path, scenario):
+    programs = ["eitc"]
+    units = build_units([scenario], programs, "claude-sonnet-5")
+    prior_requests = [(unit.custom_id, {"variables": unit.variables}) for unit in units]
+    state = BatchRunState(
+        model="claude-sonnet-5",
+        round_index=0,
+        batch_id="batch_1",
+        provider="fake",
+        submitted_at=0.0,
+        units={
+            unit.custom_id: {
+                "scenario_id": unit.scenario_id,
+                "variables": unit.variables,
+                "chunk_index": unit.chunk_index,
+                "repair": False,
+            }
+            for unit in units
+        },
+    )
+    state.save(tmp_path)
+
+    adapter = ResumeAdapter(prior_requests)
+    frame = run_batch_eval(
+        scenarios=[scenario],
+        programs=programs,
+        model_name="claude-sonnet-5",
+        model_id="claude-sonnet-5",
+        run_dir=tmp_path,
+        adapter=adapter,
+        poll_seconds=0,
+        sleep=lambda _s: None,
+        log=lambda *_a, **_k: None,
+    )
+    # The pre-existing round was polled and collected, not resubmitted:
+    # submissions grew only if a repair round was needed (it wasn't).
+    assert len(adapter.submissions) == 1
+    assert frame["prediction"].notna().all()

--- a/uv.lock
+++ b/uv.lock
@@ -195,6 +195,25 @@ wheels = [
 ]
 
 [[package]]
+name = "anthropic"
+version = "0.115.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "docstring-parser" },
+    { name = "httpx" },
+    { name = "jiter" },
+    { name = "pydantic" },
+    { name = "sniffio" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/99/e2/e27b1e70b1ddcda72362d6a26c9c699a46173d48a6c7ba966e8cc97a6c4d/anthropic-0.115.1.tar.gz", hash = "sha256:040287319abb909acf1cc49d83c0405dc0b1121ef257034b02c2b54151cf2446", size = 949185, upload-time = "2026-07-01T21:54:19.05Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/85/3c/501c58a8f8c68811079e218a25d8672fe4fb9a650a4655e499e24d9375e9/anthropic-0.115.1-py3-none-any.whl", hash = "sha256:685fa94964c1b9428f6a76e42d0dbae49aa2016f5ad386a96becac04c5e80ef9", size = 957006, upload-time = "2026-07-01T21:54:17.392Z" },
+]
+
+[[package]]
 name = "anyio"
 version = "4.12.1"
 source = { registry = "https://pypi.org/simple" }
@@ -847,6 +866,15 @@ wheels = [
 ]
 
 [[package]]
+name = "docstring-parser"
+version = "0.18.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/4d/f332313098c1de1b2d2ff91cf2674415cc7cddab2ca1b01ae29774bd5fdf/docstring_parser-0.18.0.tar.gz", hash = "sha256:292510982205c12b1248696f44959db3cdd1740237a968ea1e2e7a900eeb2015", size = 29341, upload-time = "2026-04-14T04:09:19.867Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/5f/ed01f9a3cdffbd5a008556fc7b2a08ddb1cc6ace7effa7340604b1d16699/docstring_parser-0.18.0-py3-none-any.whl", hash = "sha256:b3fcbed555c47d8479be0796ef7e19c2670d428d72e96da63f3a40122860374b", size = 22484, upload-time = "2026-04-14T04:09:18.638Z" },
+]
+
+[[package]]
 name = "dpath"
 version = "2.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1134,6 +1162,11 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/4a/c9/db44165ba7c581268c6d46017ef63339110378305062830104fc7fa144cb/google_auth-2.53.0-py3-none-any.whl", hash = "sha256:6e7449917c599b35126a99ec268ec6880301f2fea41dce198fe8fd83ff642b68", size = 246071, upload-time = "2026-05-15T20:53:05.609Z" },
 ]
 
+[package.optional-dependencies]
+requests = [
+    { name = "requests" },
+]
+
 [[package]]
 name = "google-cloud-core"
 version = "2.6.0"
@@ -1197,6 +1230,27 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/08/a5/7b059810934a09fb3ccb657e0843813c1fee1183d3bc2c8041800374aa2c/google_crc32c-1.8.0-cp314-cp314-win_amd64.whl", hash = "sha256:d511b3153e7011a27ab6ee6bb3a5404a55b994dc1a7322c0b87b29606d9790e2", size = 34878, upload-time = "2025-12-16T00:35:23.142Z" },
     { url = "https://files.pythonhosted.org/packages/52/c5/c171e4d8c44fec1422d801a6d2e5d7ddabd733eeda505c79730ee9607f07/google_crc32c-1.8.0-pp311-pypy311_pp73-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:87fa445064e7db928226b2e6f0d5304ab4cd0339e664a4e9a25029f384d9bb93", size = 28615, upload-time = "2025-12-16T00:40:29.298Z" },
     { url = "https://files.pythonhosted.org/packages/9c/97/7d75fe37a7a6ed171a2cf17117177e7aab7e6e0d115858741b41e9dd4254/google_crc32c-1.8.0-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f639065ea2042d5c034bf258a9f085eaa7af0cd250667c0635a3118e8f92c69c", size = 28800, upload-time = "2025-12-16T00:40:30.322Z" },
+]
+
+[[package]]
+name = "google-genai"
+version = "2.10.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "google-auth", extra = ["requests"] },
+    { name = "httpx" },
+    { name = "pydantic" },
+    { name = "requests" },
+    { name = "sniffio" },
+    { name = "tenacity" },
+    { name = "typing-extensions" },
+    { name = "websockets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cd/fe/b796087493c3c55371aa58b9f264841ace5bfdf8c668cafa7afa33c44bec/google_genai-2.10.0.tar.gz", hash = "sha256:77912cd558cd7dfd5b75c25fd1c609e78d7954dde583331104022a46ea90f9ee", size = 600039, upload-time = "2026-06-24T01:33:18.157Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/39/00bcfd94de255d24249401efff4f48d77bf6066b46447e519fa193c0c299/google_genai-2.10.0-py3-none-any.whl", hash = "sha256:d5350311567ae660c24cbc1752aee4b3d660f89c0106d2dcd2a69978c35afe1e", size = 957974, upload-time = "2026-06-24T01:33:16.296Z" },
 ]
 
 [[package]]
@@ -2882,6 +2936,8 @@ name = "policybench"
 version = "2.0.0"
 source = { editable = "." }
 dependencies = [
+    { name = "anthropic" },
+    { name = "google-genai" },
     { name = "litellm", extra = ["caching"] },
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
@@ -2906,6 +2962,8 @@ docs = [
 
 [package.metadata]
 requires-dist = [
+    { name = "anthropic", specifier = ">=0.115.1" },
+    { name = "google-genai", specifier = ">=2.10.0" },
     { name = "ipykernel", marker = "extra == 'docs'", specifier = ">=6.0" },
     { name = "jupyter-book", marker = "extra == 'docs'", specifier = ">=2.0" },
     { name = "litellm", extras = ["caching"], specifier = ">=1.30" },
@@ -4490,6 +4548,74 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/2c/41/aa4bf9664e4cda14c3b39865b12251e8e7d239f4cd0e3cc1b6c2ccde25c1/websocket_client-1.9.0.tar.gz", hash = "sha256:9e813624b6eb619999a97dc7958469217c3176312b3a16a4bd1bc7e08a46ec98", size = 70576, upload-time = "2025-10-07T21:16:36.495Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/34/db/b10e48aa8fff7407e67470363eac595018441cf32d5e1001567a7aeba5d2/websocket_client-1.9.0-py3-none-any.whl", hash = "sha256:af248a825037ef591efbf6ed20cc5faa03d3b47b9e5a2230a529eeee1c1fc3ef", size = 82616, upload-time = "2025-10-07T21:16:34.951Z" },
+]
+
+[[package]]
+name = "websockets"
+version = "16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/04/24/4b2031d72e840ce4c1ccb255f693b15c334757fc50023e4db9537080b8c4/websockets-16.0.tar.gz", hash = "sha256:5f6261a5e56e8d5c42a4497b364ea24d94d9563e8fbd44e78ac40879c60179b5", size = 179346, upload-time = "2026-01-10T09:23:47.181Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/20/74/221f58decd852f4b59cc3354cccaf87e8ef695fede361d03dc9a7396573b/websockets-16.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:04cdd5d2d1dacbad0a7bf36ccbcd3ccd5a30ee188f2560b7a62a30d14107b31a", size = 177343, upload-time = "2026-01-10T09:22:21.28Z" },
+    { url = "https://files.pythonhosted.org/packages/19/0f/22ef6107ee52ab7f0b710d55d36f5a5d3ef19e8a205541a6d7ffa7994e5a/websockets-16.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:8ff32bb86522a9e5e31439a58addbb0166f0204d64066fb955265c4e214160f0", size = 175021, upload-time = "2026-01-10T09:22:22.696Z" },
+    { url = "https://files.pythonhosted.org/packages/10/40/904a4cb30d9b61c0e278899bf36342e9b0208eb3c470324a9ecbaac2a30f/websockets-16.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:583b7c42688636f930688d712885cf1531326ee05effd982028212ccc13e5957", size = 175320, upload-time = "2026-01-10T09:22:23.94Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/2f/4b3ca7e106bc608744b1cdae041e005e446124bebb037b18799c2d356864/websockets-16.0-cp310-cp310-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:7d837379b647c0c4c2355c2499723f82f1635fd2c26510e1f587d89bc2199e72", size = 183815, upload-time = "2026-01-10T09:22:25.469Z" },
+    { url = "https://files.pythonhosted.org/packages/86/26/d40eaa2a46d4302becec8d15b0fc5e45bdde05191e7628405a19cf491ccd/websockets-16.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:df57afc692e517a85e65b72e165356ed1df12386ecb879ad5693be08fac65dde", size = 185054, upload-time = "2026-01-10T09:22:27.101Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/ba/6500a0efc94f7373ee8fefa8c271acdfd4dca8bd49a90d4be7ccabfc397e/websockets-16.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:2b9f1e0d69bc60a4a87349d50c09a037a2607918746f07de04df9e43252c77a3", size = 184565, upload-time = "2026-01-10T09:22:28.293Z" },
+    { url = "https://files.pythonhosted.org/packages/04/b4/96bf2cee7c8d8102389374a2616200574f5f01128d1082f44102140344cc/websockets-16.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:335c23addf3d5e6a8633f9f8eda77efad001671e80b95c491dd0924587ece0b3", size = 183848, upload-time = "2026-01-10T09:22:30.394Z" },
+    { url = "https://files.pythonhosted.org/packages/02/8e/81f40fb00fd125357814e8c3025738fc4ffc3da4b6b4a4472a82ba304b41/websockets-16.0-cp310-cp310-win32.whl", hash = "sha256:37b31c1623c6605e4c00d466c9d633f9b812ea430c11c8a278774a1fde1acfa9", size = 178249, upload-time = "2026-01-10T09:22:32.083Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/5f/7e40efe8df57db9b91c88a43690ac66f7b7aa73a11aa6a66b927e44f26fa/websockets-16.0-cp310-cp310-win_amd64.whl", hash = "sha256:8e1dab317b6e77424356e11e99a432b7cb2f3ec8c5ab4dabbcee6add48f72b35", size = 178685, upload-time = "2026-01-10T09:22:33.345Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/db/de907251b4ff46ae804ad0409809504153b3f30984daf82a1d84a9875830/websockets-16.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:31a52addea25187bde0797a97d6fc3d2f92b6f72a9370792d65a6e84615ac8a8", size = 177340, upload-time = "2026-01-10T09:22:34.539Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/fa/abe89019d8d8815c8781e90d697dec52523fb8ebe308bf11664e8de1877e/websockets-16.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:417b28978cdccab24f46400586d128366313e8a96312e4b9362a4af504f3bbad", size = 175022, upload-time = "2026-01-10T09:22:36.332Z" },
+    { url = "https://files.pythonhosted.org/packages/58/5d/88ea17ed1ded2079358b40d31d48abe90a73c9e5819dbcde1606e991e2ad/websockets-16.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:af80d74d4edfa3cb9ed973a0a5ba2b2a549371f8a741e0800cb07becdd20f23d", size = 175319, upload-time = "2026-01-10T09:22:37.602Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/ae/0ee92b33087a33632f37a635e11e1d99d429d3d323329675a6022312aac2/websockets-16.0-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:08d7af67b64d29823fed316505a89b86705f2b7981c07848fb5e3ea3020c1abe", size = 184631, upload-time = "2026-01-10T09:22:38.789Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/c5/27178df583b6c5b31b29f526ba2da5e2f864ecc79c99dae630a85d68c304/websockets-16.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7be95cfb0a4dae143eaed2bcba8ac23f4892d8971311f1b06f3c6b78952ee70b", size = 185870, upload-time = "2026-01-10T09:22:39.893Z" },
+    { url = "https://files.pythonhosted.org/packages/87/05/536652aa84ddc1c018dbb7e2c4cbcd0db884580bf8e95aece7593fde526f/websockets-16.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:d6297ce39ce5c2e6feb13c1a996a2ded3b6832155fcfc920265c76f24c7cceb5", size = 185361, upload-time = "2026-01-10T09:22:41.016Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/e2/d5332c90da12b1e01f06fb1b85c50cfc489783076547415bf9f0a659ec19/websockets-16.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:1c1b30e4f497b0b354057f3467f56244c603a79c0d1dafce1d16c283c25f6e64", size = 184615, upload-time = "2026-01-10T09:22:42.442Z" },
+    { url = "https://files.pythonhosted.org/packages/77/fb/d3f9576691cae9253b51555f841bc6600bf0a983a461c79500ace5a5b364/websockets-16.0-cp311-cp311-win32.whl", hash = "sha256:5f451484aeb5cafee1ccf789b1b66f535409d038c56966d6101740c1614b86c6", size = 178246, upload-time = "2026-01-10T09:22:43.654Z" },
+    { url = "https://files.pythonhosted.org/packages/54/67/eaff76b3dbaf18dcddabc3b8c1dba50b483761cccff67793897945b37408/websockets-16.0-cp311-cp311-win_amd64.whl", hash = "sha256:8d7f0659570eefb578dacde98e24fb60af35350193e4f56e11190787bee77dac", size = 178684, upload-time = "2026-01-10T09:22:44.941Z" },
+    { url = "https://files.pythonhosted.org/packages/84/7b/bac442e6b96c9d25092695578dda82403c77936104b5682307bd4deb1ad4/websockets-16.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:71c989cbf3254fbd5e84d3bff31e4da39c43f884e64f2551d14bb3c186230f00", size = 177365, upload-time = "2026-01-10T09:22:46.787Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/fe/136ccece61bd690d9c1f715baaeefd953bb2360134de73519d5df19d29ca/websockets-16.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:8b6e209ffee39ff1b6d0fa7bfef6de950c60dfb91b8fcead17da4ee539121a79", size = 175038, upload-time = "2026-01-10T09:22:47.999Z" },
+    { url = "https://files.pythonhosted.org/packages/40/1e/9771421ac2286eaab95b8575b0cb701ae3663abf8b5e1f64f1fd90d0a673/websockets-16.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:86890e837d61574c92a97496d590968b23c2ef0aeb8a9bc9421d174cd378ae39", size = 175328, upload-time = "2026-01-10T09:22:49.809Z" },
+    { url = "https://files.pythonhosted.org/packages/18/29/71729b4671f21e1eaa5d6573031ab810ad2936c8175f03f97f3ff164c802/websockets-16.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:9b5aca38b67492ef518a8ab76851862488a478602229112c4b0d58d63a7a4d5c", size = 184915, upload-time = "2026-01-10T09:22:51.071Z" },
+    { url = "https://files.pythonhosted.org/packages/97/bb/21c36b7dbbafc85d2d480cd65df02a1dc93bf76d97147605a8e27ff9409d/websockets-16.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e0334872c0a37b606418ac52f6ab9cfd17317ac26365f7f65e203e2d0d0d359f", size = 186152, upload-time = "2026-01-10T09:22:52.224Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/34/9bf8df0c0cf88fa7bfe36678dc7b02970c9a7d5e065a3099292db87b1be2/websockets-16.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:a0b31e0b424cc6b5a04b8838bbaec1688834b2383256688cf47eb97412531da1", size = 185583, upload-time = "2026-01-10T09:22:53.443Z" },
+    { url = "https://files.pythonhosted.org/packages/47/88/4dd516068e1a3d6ab3c7c183288404cd424a9a02d585efbac226cb61ff2d/websockets-16.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:485c49116d0af10ac698623c513c1cc01c9446c058a4e61e3bf6c19dff7335a2", size = 184880, upload-time = "2026-01-10T09:22:55.033Z" },
+    { url = "https://files.pythonhosted.org/packages/91/d6/7d4553ad4bf1c0421e1ebd4b18de5d9098383b5caa1d937b63df8d04b565/websockets-16.0-cp312-cp312-win32.whl", hash = "sha256:eaded469f5e5b7294e2bdca0ab06becb6756ea86894a47806456089298813c89", size = 178261, upload-time = "2026-01-10T09:22:56.251Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/f0/f3a17365441ed1c27f850a80b2bc680a0fa9505d733fe152fdf5e98c1c0b/websockets-16.0-cp312-cp312-win_amd64.whl", hash = "sha256:5569417dc80977fc8c2d43a86f78e0a5a22fee17565d78621b6bb264a115d4ea", size = 178693, upload-time = "2026-01-10T09:22:57.478Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/9c/baa8456050d1c1b08dd0ec7346026668cbc6f145ab4e314d707bb845bf0d/websockets-16.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:878b336ac47938b474c8f982ac2f7266a540adc3fa4ad74ae96fea9823a02cc9", size = 177364, upload-time = "2026-01-10T09:22:59.333Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/0c/8811fc53e9bcff68fe7de2bcbe75116a8d959ac699a3200f4847a8925210/websockets-16.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:52a0fec0e6c8d9a784c2c78276a48a2bdf099e4ccc2a4cad53b27718dbfd0230", size = 175039, upload-time = "2026-01-10T09:23:01.171Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/82/39a5f910cb99ec0b59e482971238c845af9220d3ab9fa76dd9162cda9d62/websockets-16.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e6578ed5b6981005df1860a56e3617f14a6c307e6a71b4fff8c48fdc50f3ed2c", size = 175323, upload-time = "2026-01-10T09:23:02.341Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/28/0a25ee5342eb5d5f297d992a77e56892ecb65e7854c7898fb7d35e9b33bd/websockets-16.0-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:95724e638f0f9c350bb1c2b0a7ad0e83d9cc0c9259f3ea94e40d7b02a2179ae5", size = 184975, upload-time = "2026-01-10T09:23:03.756Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/66/27ea52741752f5107c2e41fda05e8395a682a1e11c4e592a809a90c6a506/websockets-16.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c0204dc62a89dc9d50d682412c10b3542d748260d743500a85c13cd1ee4bde82", size = 186203, upload-time = "2026-01-10T09:23:05.01Z" },
+    { url = "https://files.pythonhosted.org/packages/37/e5/8e32857371406a757816a2b471939d51c463509be73fa538216ea52b792a/websockets-16.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:52ac480f44d32970d66763115edea932f1c5b1312de36df06d6b219f6741eed8", size = 185653, upload-time = "2026-01-10T09:23:06.301Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/67/f926bac29882894669368dc73f4da900fcdf47955d0a0185d60103df5737/websockets-16.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6e5a82b677f8f6f59e8dfc34ec06ca6b5b48bc4fcda346acd093694cc2c24d8f", size = 184920, upload-time = "2026-01-10T09:23:07.492Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/a1/3d6ccdcd125b0a42a311bcd15a7f705d688f73b2a22d8cf1c0875d35d34a/websockets-16.0-cp313-cp313-win32.whl", hash = "sha256:abf050a199613f64c886ea10f38b47770a65154dc37181bfaff70c160f45315a", size = 178255, upload-time = "2026-01-10T09:23:09.245Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/ae/90366304d7c2ce80f9b826096a9e9048b4bb760e44d3b873bb272cba696b/websockets-16.0-cp313-cp313-win_amd64.whl", hash = "sha256:3425ac5cf448801335d6fdc7ae1eb22072055417a96cc6b31b3861f455fbc156", size = 178689, upload-time = "2026-01-10T09:23:10.483Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/1d/e88022630271f5bd349ed82417136281931e558d628dd52c4d8621b4a0b2/websockets-16.0-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:8cc451a50f2aee53042ac52d2d053d08bf89bcb31ae799cb4487587661c038a0", size = 177406, upload-time = "2026-01-10T09:23:12.178Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/78/e63be1bf0724eeb4616efb1ae1c9044f7c3953b7957799abb5915bffd38e/websockets-16.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:daa3b6ff70a9241cf6c7fc9e949d41232d9d7d26fd3522b1ad2b4d62487e9904", size = 175085, upload-time = "2026-01-10T09:23:13.511Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/f4/d3c9220d818ee955ae390cf319a7c7a467beceb24f05ee7aaaa2414345ba/websockets-16.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:fd3cb4adb94a2a6e2b7c0d8d05cb94e6f1c81a0cf9dc2694fb65c7e8d94c42e4", size = 175328, upload-time = "2026-01-10T09:23:14.727Z" },
+    { url = "https://files.pythonhosted.org/packages/63/bc/d3e208028de777087e6fb2b122051a6ff7bbcca0d6df9d9c2bf1dd869ae9/websockets-16.0-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:781caf5e8eee67f663126490c2f96f40906594cb86b408a703630f95550a8c3e", size = 185044, upload-time = "2026-01-10T09:23:15.939Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/6e/9a0927ac24bd33a0a9af834d89e0abc7cfd8e13bed17a86407a66773cc0e/websockets-16.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:caab51a72c51973ca21fa8a18bd8165e1a0183f1ac7066a182ff27107b71e1a4", size = 186279, upload-time = "2026-01-10T09:23:17.148Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/ca/bf1c68440d7a868180e11be653c85959502efd3a709323230314fda6e0b3/websockets-16.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:19c4dc84098e523fd63711e563077d39e90ec6702aff4b5d9e344a60cb3c0cb1", size = 185711, upload-time = "2026-01-10T09:23:18.372Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/f8/fdc34643a989561f217bb477cbc47a3a07212cbda91c0e4389c43c296ebf/websockets-16.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:a5e18a238a2b2249c9a9235466b90e96ae4795672598a58772dd806edc7ac6d3", size = 184982, upload-time = "2026-01-10T09:23:19.652Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/d1/574fa27e233764dbac9c52730d63fcf2823b16f0856b3329fc6268d6ae4f/websockets-16.0-cp314-cp314-win32.whl", hash = "sha256:a069d734c4a043182729edd3e9f247c3b2a4035415a9172fd0f1b71658a320a8", size = 177915, upload-time = "2026-01-10T09:23:21.458Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/f1/ae6b937bf3126b5134ce1f482365fde31a357c784ac51852978768b5eff4/websockets-16.0-cp314-cp314-win_amd64.whl", hash = "sha256:c0ee0e63f23914732c6d7e0cce24915c48f3f1512ec1d079ed01fc629dab269d", size = 178381, upload-time = "2026-01-10T09:23:22.715Z" },
+    { url = "https://files.pythonhosted.org/packages/06/9b/f791d1db48403e1f0a27577a6beb37afae94254a8c6f08be4a23e4930bc0/websockets-16.0-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:a35539cacc3febb22b8f4d4a99cc79b104226a756aa7400adc722e83b0d03244", size = 177737, upload-time = "2026-01-10T09:23:24.523Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/40/53ad02341fa33b3ce489023f635367a4ac98b73570102ad2cdd770dacc9a/websockets-16.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:b784ca5de850f4ce93ec85d3269d24d4c82f22b7212023c974c401d4980ebc5e", size = 175268, upload-time = "2026-01-10T09:23:25.781Z" },
+    { url = "https://files.pythonhosted.org/packages/74/9b/6158d4e459b984f949dcbbb0c5d270154c7618e11c01029b9bbd1bb4c4f9/websockets-16.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:569d01a4e7fba956c5ae4fc988f0d4e187900f5497ce46339c996dbf24f17641", size = 175486, upload-time = "2026-01-10T09:23:27.033Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/2d/7583b30208b639c8090206f95073646c2c9ffd66f44df967981a64f849ad/websockets-16.0-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:50f23cdd8343b984957e4077839841146f67a3d31ab0d00e6b824e74c5b2f6e8", size = 185331, upload-time = "2026-01-10T09:23:28.259Z" },
+    { url = "https://files.pythonhosted.org/packages/45/b0/cce3784eb519b7b5ad680d14b9673a31ab8dcb7aad8b64d81709d2430aa8/websockets-16.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:152284a83a00c59b759697b7f9e9cddf4e3c7861dd0d964b472b70f78f89e80e", size = 186501, upload-time = "2026-01-10T09:23:29.449Z" },
+    { url = "https://files.pythonhosted.org/packages/19/60/b8ebe4c7e89fb5f6cdf080623c9d92789a53636950f7abacfc33fe2b3135/websockets-16.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:bc59589ab64b0022385f429b94697348a6a234e8ce22544e3681b2e9331b5944", size = 186062, upload-time = "2026-01-10T09:23:31.368Z" },
+    { url = "https://files.pythonhosted.org/packages/88/a8/a080593f89b0138b6cba1b28f8df5673b5506f72879322288b031337c0b8/websockets-16.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:32da954ffa2814258030e5a57bc73a3635463238e797c7375dc8091327434206", size = 185356, upload-time = "2026-01-10T09:23:32.627Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/b6/b9afed2afadddaf5ebb2afa801abf4b0868f42f8539bfe4b071b5266c9fe/websockets-16.0-cp314-cp314t-win32.whl", hash = "sha256:5a4b4cc550cb665dd8a47f868c8d04c8230f857363ad3c9caf7a0c3bf8c61ca6", size = 178085, upload-time = "2026-01-10T09:23:33.816Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/3e/28135a24e384493fa804216b79a6a6759a38cc4ff59118787b9fb693df93/websockets-16.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b14dc141ed6d2dde437cddb216004bcac6a1df0935d79656387bd41632ba0bbd", size = 178531, upload-time = "2026-01-10T09:23:35.016Z" },
+    { url = "https://files.pythonhosted.org/packages/72/07/c98a68571dcf256e74f1f816b8cc5eae6eb2d3d5cfa44d37f801619d9166/websockets-16.0-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:349f83cd6c9a415428ee1005cadb5c2c56f4389bc06a9af16103c3bc3dcc8b7d", size = 174947, upload-time = "2026-01-10T09:23:36.166Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/52/93e166a81e0305b33fe416338be92ae863563fe7bce446b0f687b9df5aea/websockets-16.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:4a1aba3340a8dca8db6eb5a7986157f52eb9e436b74813764241981ca4888f03", size = 175260, upload-time = "2026-01-10T09:23:37.409Z" },
+    { url = "https://files.pythonhosted.org/packages/56/0c/2dbf513bafd24889d33de2ff0368190a0e69f37bcfa19009ef819fe4d507/websockets-16.0-pp311-pypy311_pp73-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:f4a32d1bd841d4bcbffdcb3d2ce50c09c3909fbead375ab28d0181af89fd04da", size = 176071, upload-time = "2026-01-10T09:23:39.158Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/8f/aea9c71cc92bf9b6cc0f7f70df8f0b420636b6c96ef4feee1e16f80f75dd/websockets-16.0-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0298d07ee155e2e9fda5be8a9042200dd2e3bb0b8a38482156576f863a9d457c", size = 176968, upload-time = "2026-01-10T09:23:41.031Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/3f/f70e03f40ffc9a30d817eef7da1be72ee4956ba8d7255c399a01b135902a/websockets-16.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:a653aea902e0324b52f1613332ddf50b00c06fdaf7e92624fbf8c77c78fa5767", size = 178735, upload-time = "2026-01-10T09:23:42.259Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/28/258ebab549c2bf3e64d2b0217b973467394a9cea8c42f70418ca2c5d0d2e/websockets-16.0-py3-none-any.whl", hash = "sha256:1637db62fad1dc833276dded54215f2c7fa46912301a24bd94d45d46a011ceec", size = 171598, upload-time = "2026-01-10T09:23:45.395Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Fixes #85. Stacked on #86 (the parity test covers Sonnet 5's token ceiling); retarget to main after it merges.

`eval-no-tools-batch` runs the same evaluation through each provider's batch endpoint at ~50% of synchronous prices, with the provider supplying the parallelism:

- Request bodies are the sync harness's own (`_chat_completion_request_kwargs` / `_responses_request_kwargs`), translated per provider. The Anthropic translation refuses request parameters it doesn't cover rather than dropping them silently, so sync/batch parity can't drift unnoticed.
- Batch ids persist under the run's `batches/`; rerunning resumes polling instead of resubmitting. Contract violations are re-requested in bounded repair rounds as follow-up batches, mirroring the sync repair loop.
- Output is the sync schema's `by_model/<model>.csv`, so retries, the runstore, scoring, and the dashboard export work unchanged.
- Two deliberate reporting differences: latency columns stay empty on batch rows (a batch round-trip includes provider queue time, which is not model latency), and costs are reconstructed at standard sync rates so the leaderboard basis is unchanged while actual spend halves.
- litellm's batch surface in our pinned version covers only OpenAI/Azure/Vertex, so thin native adapters (anthropic SDK, openai SDK against `/v1/responses`, google-genai inline batches) sit behind one interface. The Gemini adapter is marked experimental until its first paid run. xAI and DeepSeek have no batch APIs and stay on the chunked runner.

10 new tests (request-translation parity and its guardrail, unit expansion vs sync chunking, result normalization per provider, contract-repair targeting, end-to-end with a scripted adapter, resume-without-resubmit). Full suite: 396 passed.

Complements #84 (subprocess-timeout parallelism for the sync path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)