### PR TITLE
Unpin GPT-5.5 reasoning effort for uniform unconfigured defaults

### DIFF
--- a/paper/index.qmd
+++ b/paper/index.qmd
@@ -679,11 +679,24 @@ def sensitivity_rows() -> pd.DataFrame:
     return pd.DataFrame(rows)
 
 
-def reasoning_setup(model: str) -> str:
-    """Per-model reasoning configuration, read from the harness constants.
+# Reasoning-effort overrides in force when the frozen snapshot's runs were
+# made. Recorded here as a snapshot fact: the live harness mapping
+# (REASONING_EFFORT_OVERRIDES) was emptied on 2026-07-03 when the gpt-5.5
+# pin was removed, but this manuscript describes the frozen runs, which
+# used the pin. Assert containment so a *new* live override can never ship
+# undocumented in the manuscript.
+SNAPSHOT_REASONING_EFFORT_OVERRIDES: dict[str, str] = {"gpt-5.5": "low"}
+assert all(
+    SNAPSHOT_REASONING_EFFORT_OVERRIDES.get(k) == v
+    for k, v in REASONING_EFFORT_OVERRIDES.items()
+), "Live reasoning overrides not recorded in the snapshot config table."
 
-    Sourced from ``policybench.eval_no_tools`` so the manuscript cannot
-    drift from the code that made the requests.
+
+def reasoning_setup(model: str) -> str:
+    """Per-model reasoning configuration for the frozen snapshot's runs.
+
+    Thinking-model text derives from the live harness constants (unchanged
+    since those runs); effort overrides come from the snapshot record above.
     """
     if model in THINKING_DEFAULT_CLAUDE_MODELS:
         cap = f"{THINKING_CLAUDE_MAX_COMPLETION_TOKENS_CAP:,}"
@@ -691,8 +704,11 @@ def reasoning_setup(model: str) -> str:
             "extended thinking on (model default); thinking and answer share "
             f"a {cap}-token completion budget"
         )
-    if model in REASONING_EFFORT_OVERRIDES:
-        return f"reasoning effort pinned to {REASONING_EFFORT_OVERRIDES[model]!r}"
+    if model in SNAPSHOT_REASONING_EFFORT_OVERRIDES:
+        return (
+            "reasoning effort pinned to "
+            f"{SNAPSHOT_REASONING_EFFORT_OVERRIDES[model]!r}"
+        )
     return "no reasoning parameters sent (provider default)"
 
 
@@ -1026,7 +1042,7 @@ Aggregation proceeds in three steps. First, each household-output prediction rec
 
 The benchmark requires each model response to include numeric answers and one explanation per requested output. Both the exact-match rate and the bounded score use only the numeric answers. Explanations are retained for scenario exploration and qualitative error analysis; they should not be interpreted as faithful traces of model reasoning.
 
-Because explanations are required, the canonical task measures policy estimation under a public-facing structured-response contract, not isolated arithmetic accuracy. Prompt fairness is part of the benchmark contract. The current release uses one prompt template per country, with no model-specific tuning. Models receive the same household facts, the same requested outputs, and no web or tool access. The prompt states that unlisted numeric inputs are `0`, unlisted boolean or status facts are false, and household characteristics are constant over the tax-benefit year. Provider-specific differences are limited to the response transport needed to obtain structured output and the reasoning configuration documented per model in @tbl-model-runs: models whose provider enables reasoning by default run with extended thinking against a fixed shared completion budget, one model runs with an explicit reasoning-effort setting, and every other model receives no reasoning-control parameters. Reasoning configuration is therefore not uniform across the roster. Sampling parameters are never set; temperature and related decoding controls stay at provider defaults for every model. A rerun at strictly unconfigured provider defaults for all models is planned as a sensitivity release.
+Because explanations are required, the canonical task measures policy estimation under a public-facing structured-response contract, not isolated arithmetic accuracy. Prompt fairness is part of the benchmark contract. The current release uses one prompt template per country, with no model-specific tuning. Models receive the same household facts, the same requested outputs, and no web or tool access. The prompt states that unlisted numeric inputs are `0`, unlisted boolean or status facts are false, and household characteristics are constant over the tax-benefit year. Provider-specific differences are limited to the response transport needed to obtain structured output and the reasoning configuration documented per model in @tbl-model-runs: models whose provider enables reasoning by default run with extended thinking against a fixed shared completion budget, GPT-5.5 ran with reasoning effort pinned to low in these frozen runs, and every other model received no reasoning-control parameters. Reasoning configuration in this snapshot is therefore not uniform across the roster. Sampling parameters are never set; temperature and related decoding controls stay at provider defaults for every model. The GPT-5.5 effort pin was removed on 2026-07-03: subsequent releases send no reasoning-control parameters to any model, and a GPT-5.5 rerun at its provider default is scheduled as the first entry of that uniform-configuration pass.
 
 ### Frozen snapshot and open-set status
 

--- a/policybench/eval_no_tools.py
+++ b/policybench/eval_no_tools.py
@@ -109,9 +109,10 @@ THINKING_CLAUDE_MAX_COMPLETION_TOKENS_CAP = 16384
 # Per-model reasoning-effort overrides sent as `reasoning={"effort": ...}`.
 # Models absent from this mapping receive NO reasoning-control parameters:
 # whatever an unconfigured API call does is what the benchmark measures.
-# Keep this the single source of truth — the manuscript's model-run table
-# imports it, so any change here is documented automatically.
-REASONING_EFFORT_OVERRIDES: dict[str, str] = {"gpt-5.5": "low"}
+# EMPTY since 2026-07-03: gpt-5.5 ran with effort "low" from the May 2026
+# launch through the v1.x runs (recorded in the manuscript's snapshot
+# config); the pin was removed so every model runs unconfigured.
+REASONING_EFFORT_OVERRIDES: dict[str, str] = {}
 ANSWER_TOKENS_PER_VARIABLE = 48
 EXPLANATION_TOKENS_PER_VARIABLE = 96
 ANSWER_COMPLETION_BUFFER_TOKENS = 96


### PR DESCRIPTION
Removes the last reasoning-control override: `REASONING_EFFORT_OVERRIDES` is now empty, so every model runs with whatever an unconfigured API call does (OpenAI documents `medium` as gpt-5.5's default). The pin dated to the May 1 cleanup commit with no recorded rationale.

The manuscript continues to describe the frozen snapshot's runs truthfully: the pin moves into `SNAPSHOT_REASONING_EFFORT_OVERRIDES` (a recorded snapshot fact) with a containment assert so any future live override fails the paper build until documented. Prose updated to date the policy change and announce the GPT-5.5 default-effort rerun as the first uniform-configuration entry.

Predictions are unaffected until that rerun publishes (planned as v1.2, after the v1.1 ground-truth/weights refresh). 104/104 eval+batch tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)