### PR TITLE
Publish PolicyBench dataset v1.1 (corrected ground truth, weights unchanged)

### DIFF
--- a/app/src/components/Hero.tsx
+++ b/app/src/components/Hero.tsx
@@ -1,7 +1,7 @@
 import type { BenchData, CountryCode } from "../types";
 import SiteHeader, { type HeaderNavItem } from "./SiteHeader";
 
-const SNAPSHOT_DATE_LABEL = "Snapshot 2026-07-02";
+const SNAPSHOT_DATE_LABEL = "Snapshot 2026-07-05";
 
 export default function Hero({
   selectedView,

--- a/app/src/data.artifact.json
+++ b/app/src/data.artifact.json
@@ -1,9 +1,9 @@
 {
   "version": 1,
   "repo": "PolicyEngine/policybench",
-  "tag": "dashboard-data-20260702b",
+  "tag": "dashboard-data-20260705",
   "asset": "dashboard-data.json",
-  "url": "https://github.com/PolicyEngine/policybench/releases/download/dashboard-data-20260702b/dashboard-data.json",
-  "sha256": "7b26f03fb77c3c2683e2aa8ff9caef8c718972f174d6802c8147bc384991b74c",
-  "bytes": 43052995
+  "url": "https://github.com/PolicyEngine/policybench/releases/download/dashboard-data-20260705/dashboard-data.json",
+  "sha256": "fa10d4c745dba1e8cde92fa5eb96f8f0c0d0af6fbef79e434ce5ff38833aaa70",
+  "bytes": 43029976
 }

--- a/paper/snapshot/20260501/manifest.json
+++ b/paper/snapshot/20260501/manifest.json
@@ -20,11 +20,20 @@
   ],
   "live_dashboard_artifact": {
     "asset": "dashboard-data.json",
-    "bytes": 43052995,
-    "derivation": "dashboard-data-20260702 (frozen 13 models + Claude Fable 5 + Claude Sonnet 5) plus LLM-judge failure-mode annotations for the two Claude 5 models' 322 wrong cases (Codex-classified 2026-07-02, same taxonomy and procedure as the June audit). Scores unchanged; the combined 15-model predictions.csv.gz is attached to the release.",
-    "sha256": "7b26f03fb77c3c2683e2aa8ff9caef8c718972f174d6802c8147bc384991b74c",
-    "tag": "dashboard-data-20260702b",
-    "url": "https://github.com/PolicyEngine/policybench/releases/download/dashboard-data-20260702b/dashboard-data.json"
+    "bytes": 43029976,
+    "derivation": "PolicyBench dataset v1.1. Re-scores the frozen 15-model predictions (dashboard-data-20260702b: frozen 13 models + Claude Fable 5 + Claude Sonnet 5, predictions unchanged) against corrected US reference outputs regenerated with a direct install of policyengine-us 1.755.4 (references are a function of the engine only). Exactly three reference value cells change versus the frozen references, all upstream fixes: scenario_056 state_income_tax_before_refundable_credits 67.7394->0.0 (NJ filing-threshold floor, pe-us 1.755.3, N.J.S.A. 54A:2-4), and scenario_008 child5_head_start_eligible and scenario_100 child2_head_start_eligible 0->1 (Head Start ages 3-5, pe-us 1.755.4, 45 CFR 1302.12(b)). All 15 models gain on the corrected reference; every per-cell score change is confined to those three cells (45 of 29,760 prediction rows = 15 models x 3 cells). Population output weights are unchanged from the committed June artifact (policybench/population_weights.json, sha256 0b3b96b8...); a populace-refreshed weights build ships later as a separate version. The combined 15-model predictions.csv.gz attached to the release is byte-identical to the dashboard-data-20260702b asset.",
+    "reference_engine": {
+      "policyengine_us_version": "1.755.4",
+      "policyengine_us_source": "direct pip install",
+      "policyengine_version": "4.16.1"
+    },
+    "population_weights": {
+      "source": "committed June artifact policybench/population_weights.json (unchanged)",
+      "sha256": "0b3b96b8247477631510371b9c3b021a18a535e8ebbf8c73a8aa67cff3110cd4"
+    },
+    "sha256": "fa10d4c745dba1e8cde92fa5eb96f8f0c0d0af6fbef79e434ce5ff38833aaa70",
+    "tag": "dashboard-data-20260705",
+    "url": "https://github.com/PolicyEngine/policybench/releases/download/dashboard-data-20260705/dashboard-data.json"
   },
   "live_dashboard_note": "Two artifacts are tracked. published_dashboard_artifact pins the manuscript's frozen record: it equals the combined export of the source run data.json files listed under source_run_artifacts, byte for byte. live_dashboard_artifact is the release asset the committed pointer app/src/data.artifact.json references; it starts from the frozen export and may gain additive updates (injected metrics, newly benchmarked models) without changing the frozen models' scores. Every publish-dashboard run must update live_dashboard_artifact (tag, sha256, bytes, derivation) in the same commit as the pointer.",
   "model_response_date": "2026-06-12 to 2026-06-13",


### PR DESCRIPTION
## PolicyBench dataset v1.1 — corrected ground truth (weights unchanged)

Re-scores the frozen 15-model predictions against corrected US reference outputs and points the live dashboard at release `dashboard-data-20260705`. This is the data half of the v1.1 publish; it lands together with the dataset-version selector (#93) so one production deploy ships both the corrected data and the selector that labels it.

### What changed
- **Pointer** `app/src/data.artifact.json` → `dashboard-data-20260705`.
- **Manifest** `paper/snapshot/20260501/manifest.json` `live_dashboard_artifact` updated (tag/sha256/bytes/derivation) with added `reference_engine` and `population_weights` provenance blocks. The frozen `published_dashboard_artifact`, frozen run data, and `annotations/` are untouched.
- **Hero** `SNAPSHOT_DATE_LABEL` → `Snapshot 2026-07-05`.

### Provenance
- Reference outputs regenerated with a **direct pip install of policyengine-us 1.755.4** (policyengine 4.16.1). References are a function of the engine only, over the frozen scenario households.
- **Predictions are frozen** — models were not re-run. The attached `predictions.csv.gz` is byte-identical to the `dashboard-data-20260702b` asset (15 models: frozen 13 + Claude Fable 5 + Claude Sonnet 5).
- **Population weights are unchanged**: `policybench/population_weights.json` (committed June artifact, sha256 `0b3b96b8…`) is untouched. A populace-refreshed weights build ships later as a separate version.

### The three corrected reference cells (of 1,984)
| scenario | variable | old ref | new ref | upstream fix |
|---|---|--:|--:|---|
| scenario_056 | state_income_tax_before_refundable_credits | 67.7394 | 0.0 | NJ filing-threshold floor (pe-us 1.755.3, N.J.S.A. 54A:2-4) |
| scenario_008 | child5_head_start_eligible | 0 | 1 | Head Start ages 3–5 (pe-us 1.755.4, 45 CFR 1302.12(b)) |
| scenario_100 | child2_head_start_eligible | 0 | 1 | Head Start ages 3–5 (pe-us 1.755.4, 45 CFR 1302.12(b)) |

### Verification (denominators printed)
- A **control export** of the frozen references reproduces the live `dashboard-data-20260702b` modelStats to **0.00e+00** across 15 models × 5 fields — the environment and pipeline are faithful.
- Only **3 of 1,984** reference cells change; every per-cell score change is confined to those 3 cells (**45 of 29,760** prediction rows = 15 models × 3).
- **All 15 models gain** on both the headline and aggregate scores.
- Release assets re-downloaded and sha256-verified against the pointer.
- `bun run lint` clean, `bun test tests` 69 pass, `bun run build` materializes both dataset versions (v1.1 from the 20260705 pointer, v1.0 from 20260625). Full Python suite: 406 passed, 5 skipped.

### Assets
- `dashboard-data.json` sha256 `fa10d4c745dba1e8cde92fa5eb96f8f0c0d0af6fbef79e434ce5ff38833aaa70` (43,029,976 bytes)
- `predictions.csv.gz` sha256 `1548774d1cae644fd898439be055edc60294e7dfca216c0b38b6c6828e1d3537` (10,133,588 bytes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
