### PR TITLE
Repoint at dashboard-data-20260705 (patched in place)

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "policybench",
+      "runtimeExecutable": "bash",
+      "runtimeArgs": ["-lc", "cd app && PORT=3737 bun run dev"],
+      "port": 3737
+    }
+  ]
+}

--- a/app/src/data.artifact.json
+++ b/app/src/data.artifact.json
@@ -1,9 +1,9 @@
 {
   "version": 1,
   "repo": "PolicyEngine/policybench",
-  "tag": "dashboard-data-20260705b",
+  "tag": "dashboard-data-20260705",
   "asset": "dashboard-data.json",
-  "url": "https://github.com/PolicyEngine/policybench/releases/download/dashboard-data-20260705b/dashboard-data.json",
+  "url": "https://github.com/PolicyEngine/policybench/releases/download/dashboard-data-20260705/dashboard-data.json",
   "sha256": "96b30cff81c666effe1da0edce135aa2741709f37d614c9fbfc9a1e5cfafe24b",
   "bytes": 43030043
 }

--- a/paper/snapshot/20260501/manifest.json
+++ b/paper/snapshot/20260501/manifest.json
@@ -22,7 +22,7 @@
     "asset": "dashboard-data.json",
     "bytes": 43030043,
     "derivation": "PolicyBench dataset v1.1. Re-scores the frozen 15-model predictions (dashboard-data-20260702b: frozen 13 models + Claude Fable 5 + Claude Sonnet 5, predictions unchanged) against corrected US reference outputs regenerated with a direct install of policyengine-us 1.755.4 (references are a function of the engine only). Exactly three reference value cells change versus the frozen references, all upstream fixes: scenario_056 state_income_tax_before_refundable_credits 67.7394->0.0 (NJ filing-threshold floor, pe-us 1.755.3, N.J.S.A. 54A:2-4), and scenario_008 child5_head_start_eligible and scenario_100 child2_head_start_eligible 0->1 (Head Start ages 3-5, pe-us 1.755.4, 45 CFR 1302.12(b)). All 15 models gain on the corrected reference; every per-cell score change is confined to those three cells (45 of 29,760 prediction rows = 15 models x 3 cells). Population output weights are unchanged from the committed June artifact (policybench/population_weights.json, sha256 0b3b96b8...); a populace-refreshed weights build ships later as a separate version. The combined 15-model predictions.csv.gz attached to the release is byte-identical to the dashboard-data-20260702b asset.",
-    "notes": "20260705b patches claude-fable-5 usage fields (costUsd/costPerHousehold/latencySeconds/totalTokens) zeroed by the export rebuild; scores identical to 20260705.",
+    "notes": "v1.1 corrected-references release; claude-fable-5 usage fields are artifact-level values (per-row usage not present in predictions.csv; run reconstructed from the 20260701 artifact).",
     "population_weights": {
       "sha256": "0b3b96b8247477631510371b9c3b021a18a535e8ebbf8c73a8aa67cff3110cd4",
       "source": "committed June artifact policybench/population_weights.json (unchanged)"
@@ -33,8 +33,8 @@
       "policyengine_version": "4.16.1"
     },
     "sha256": "96b30cff81c666effe1da0edce135aa2741709f37d614c9fbfc9a1e5cfafe24b",
-    "tag": "dashboard-data-20260705b",
-    "url": "https://github.com/PolicyEngine/policybench/releases/download/dashboard-data-20260705b/dashboard-data.json"
+    "tag": "dashboard-data-20260705",
+    "url": "https://github.com/PolicyEngine/policybench/releases/download/dashboard-data-20260705/dashboard-data.json"
   },
   "live_dashboard_note": "Two artifacts are tracked. published_dashboard_artifact pins the manuscript's frozen record: it equals the combined export of the source run data.json files listed under source_run_artifacts, byte for byte. live_dashboard_artifact is the release asset the committed pointer app/src/data.artifact.json references; it starts from the frozen export and may gain additive updates (injected metrics, newly benchmarked models) without changing the frozen models' scores. Every publish-dashboard run must update live_dashboard_artifact (tag, sha256, bytes, derivation) in the same commit as the pointer.",
   "model_response_date": "2026-06-12 to 2026-06-13",


### PR DESCRIPTION
Per Max: v1.1 was hours old with no consumers, so the Fable-usage patch is folded into the 20260705 asset itself (`gh release upload --clobber`; re-downloaded sha `96b30cff…` matches the pointer). This PR just moves the pointer/manifest back from the now-redundant 20260705b tag, which gets deleted after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)