### PR TITLE
Run orchestrator: model cards, supervised runs, onboarding gauntlet, fold-board

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,10 @@ ruff format .             # Format
 - `policybench/ground_truth.py` — PE-US calculations
 - `policybench/prompts.py` — Natural language prompt templates
 - `policybench/eval_no_tools.py` — LiteLLM-based AI-alone benchmark
+- `policybench/model_cards.py` — Per-model serving treatments (contracts, chunking, timeouts)
+- `policybench/supervisor.py` — Supervised runs: scenario work queue, budget governor (`policybench run`)
+- `policybench/onboard.py` — New-model probe gauntlet (`policybench onboard`)
+- `policybench/fold_board.py` — Fold new models into a staged board (`policybench fold-board`)
 - `policybench/analysis.py` — Metrics and reporting
 
 ## Testing

--- a/policybench/cli.py
+++ b/policybench/cli.py
@@ -870,6 +870,67 @@ def main():
         help="Validate and write the pointer without uploading",
     )
 
+    run_parser = subparsers.add_parser(
+        "run",
+        help="Supervised benchmark run: per-scenario work queue, adaptive "
+        "concurrency, budget governor, heartbeat state file, resumable",
+    )
+    run_parser.add_argument("--model", required=True, help="Model key from config")
+    run_parser.add_argument("--scenario-manifest", required=True)
+    run_parser.add_argument("--run-dir", required=True)
+    run_parser.add_argument(
+        "--budget-usd",
+        type=float,
+        default=None,
+        help="Stop dispatching at 90%% of this spend; omit for no cap",
+    )
+    run_parser.add_argument("--max-workers", type=int, default=4)
+    run_parser.add_argument(
+        "--max-rounds",
+        type=int,
+        default=4,
+        help="Retry rounds for scenarios that fail or time out",
+    )
+
+    onboard_parser = subparsers.add_parser(
+        "onboard",
+        help="Probe a new model's serving stack (contracts, chunking, "
+        "latency) and print a suggested ModelCard",
+    )
+    onboard_parser.add_argument(
+        "--model-id", required=True, help="Full litellm id, e.g. openrouter/x/y"
+    )
+    onboard_parser.add_argument("--scenario-manifest", required=True)
+    onboard_parser.add_argument(
+        "--report-output", default=None, help="Optional path for the report"
+    )
+
+    fold_parser = subparsers.add_parser(
+        "fold-board",
+        help="Fold new model prediction CSVs into an existing board and "
+        "stage the export for review",
+    )
+    fold_parser.add_argument(
+        "--base", required=True, help="Current board's combined predictions.csv"
+    )
+    fold_parser.add_argument(
+        "--add",
+        action="append",
+        required=True,
+        help="Predictions CSV for one new model (repeatable)",
+    )
+    fold_parser.add_argument(
+        "--scoring-source",
+        required=True,
+        help="Directory holding reference_outputs.csv and scenarios.csv",
+    )
+    fold_parser.add_argument("--out", required=True, help="Staging directory")
+    fold_parser.add_argument(
+        "--no-export",
+        action="store_true",
+        help="Skip the country export (combine and gate only)",
+    )
+
     args = parser.parse_args()
 
     # Enable disk cache for ordinary eval calls. Contract-failure retry/repair
@@ -978,6 +1039,61 @@ def main():
                 f"{args.split_seed}). Keep *-private files out of public "
                 "artifacts."
             )
+
+    elif args.command == "run":
+        from policybench.supervisor import Supervisor
+
+        supervisor = Supervisor(
+            model=args.model,
+            manifest=Path(args.scenario_manifest),
+            run_dir=Path(args.run_dir),
+            budget_usd=args.budget_usd,
+            max_workers=args.max_workers,
+            max_rounds=args.max_rounds,
+        )
+        state = supervisor.run()
+        print(
+            f"{state.model}: {len(state.completed)}/{state.total} scenarios, "
+            f"${state.spent_usd:.2f} spent"
+        )
+        if supervisor.projection_warning:
+            print(f"WARNING: {supervisor.projection_warning}")
+        if state.stopped_reason:
+            print(f"STOPPED: {state.stopped_reason}")
+            raise SystemExit(1)
+
+    elif args.command == "onboard":
+        from policybench.config import PROGRAMS
+        from policybench.onboard import format_report, run_gauntlet
+        from policybench.scenarios import load_scenarios_from_manifest
+        from policybench.spec import expand_programs_for_scenario
+
+        scenarios = load_scenarios_from_manifest(args.scenario_manifest)
+        scenario = scenarios[0]
+        variables = expand_programs_for_scenario(list(PROGRAMS), scenario)
+        report = run_gauntlet(args.model_id, scenario, variables)
+        text = format_report(report)
+        print(text)
+        if args.report_output:
+            Path(args.report_output).write_text(text)
+
+    elif args.command == "fold-board":
+        from policybench.fold_board import fold_board
+
+        result = fold_board(
+            base_predictions=Path(args.base),
+            additions=[Path(p) for p in args.add],
+            scoring_source=Path(args.scoring_source),
+            out_dir=Path(args.out),
+            export=not args.no_export,
+        )
+        for name in result["folded"]:
+            print(f"folded: {name}")
+        for name, reason in result["excluded"].items():
+            print(f"EXCLUDED {name}: {reason}")
+        print(f"board: {result['models']} models, {result['rows']} rows")
+        if result["summary"] is not None:
+            print(result["summary"].to_string(index=False))
 
     elif args.command == "eval-no-tools":
         from policybench.eval_no_tools import (

--- a/policybench/eval_no_tools.py
+++ b/policybench/eval_no_tools.py
@@ -15,6 +15,7 @@ import pandas as pd
 from litellm import completion, completion_cost, responses
 
 from policybench.config import MODELS, PROGRAMS
+from policybench.model_cards import card_for
 
 # litellm resolves an unprefixed model's provider (and prices it) through its
 # model-cost map, whose remote refresh can time out mid-run and whose bundled
@@ -113,22 +114,9 @@ THINKING_CLAUDE_MAX_COMPLETION_TOKENS_CAP = 16384
 # launch through the v1.x runs (recorded in the manuscript's snapshot
 # config); the pin was removed so every model runs unconfigured.
 REASONING_EFFORT_OVERRIDES: dict[str, str] = {}
-# Models that reason by default when unconfigured, billing reasoning against
-# the completion budget — they get thinking-class headroom like the Claude 5s,
-# and the thinking-class request timeout (long thinks exceed the 20s default;
-# the DeepSeek smoke timed out at exactly that ceiling).
-REASONING_DEFAULT_OPENAI_MODELS = ("gpt-5.5",)
-REASONING_DEFAULT_OPEN_WEIGHT_MODELS = (
-    "deepseek/deepseek-v4-pro",
-    "deepseek/deepseek-v4-flash",
-    "openrouter/moonshotai/kimi-k2.6",
-    "openrouter/z-ai/glm-5.2",
-    "openrouter/minimax/minimax-m3",
-    "openrouter/qwen/qwen3.7-max",
-)
-REASONING_DEFAULT_MODELS = (
-    REASONING_DEFAULT_OPENAI_MODELS + REASONING_DEFAULT_OPEN_WEIGHT_MODELS
-)
+# Per-model serving treatments (answer contract, chunking, timeouts,
+# thinking-class budgets) live in policybench/model_cards.py; family-prefix
+# heuristics below are the fallback for models without a card.
 ANSWER_TOKENS_PER_VARIABLE = 48
 EXPLANATION_TOKENS_PER_VARIABLE = 96
 ANSWER_COMPLETION_BUFFER_TOKENS = 96
@@ -136,23 +124,6 @@ ANSWER_FUNCTION_NAME = "submit_outputs"
 EXPLANATION_FUNCTION_NAME = "submit_explanations"
 PROMPT_CONTRACT_VERSION = "2026-05-13-nested-output-explanations"
 CLAUDE_EXPLANATION_CHUNK_SIZE = 1
-GPT55_EXPLANATION_CHUNK_SIZE = 3
-OPEN_WEIGHT_EXPLANATION_CHUNK_SIZE = 3
-# Kimi K2.6 and GLM-5.2 at default reasoning effort do not converge on
-# whole-scenario requests: GLM reasons to the full 16,384-token ceiling
-# (both contracts), and Kimi pours its reasoning stream into the JSON
-# explanation fields until the budget truncates the document mid-structure.
-# Probed 2026-07-05: at 1-3 variables per call both stop cleanly within
-# ~1,500 completion tokens.
-# Qwen3.7-max joined after its whole-scenario runs failed deterministically
-# on larger households: reasoning plus a 30-variable JSON document exceeds
-# the 300s timeout every attempt (42/100 scenarios completed across three
-# passes with zero marginal progress).
-CHUNKED_OPEN_WEIGHT_MODELS = (
-    "openrouter/moonshotai/kimi-k2.6",
-    "openrouter/z-ai/glm-5.2",
-    "openrouter/qwen/qwen3.7-max",
-)
 
 
 class RequestWallTimeoutError(TimeoutError):
@@ -362,12 +333,13 @@ def _parse_standalone_number(text: str) -> float | None:
 def _required_explanation_chunk_size(
     model_id: str, include_explanations: bool
 ) -> int | None:
-    if include_explanations and model_id.startswith("claude-"):
+    if not include_explanations:
+        return None
+    card = card_for(model_id)
+    if card is not None and card.explanation_chunk_size is not None:
+        return card.explanation_chunk_size
+    if model_id.startswith("claude-"):
         return CLAUDE_EXPLANATION_CHUNK_SIZE
-    if include_explanations and model_id == "gpt-5.5":
-        return GPT55_EXPLANATION_CHUNK_SIZE
-    if include_explanations and model_id in CHUNKED_OPEN_WEIGHT_MODELS:
-        return OPEN_WEIGHT_EXPLANATION_CHUNK_SIZE
     return None
 
 
@@ -426,7 +398,8 @@ def _completion_controls(
                 base_tokens, variables, include_explanations
             )
         }
-    if model_id in REASONING_DEFAULT_MODELS:
+    card = card_for(model_id)
+    if card is not None and card.thinking_budget:
         # Reasoning-by-default models bill reasoning against the same
         # completion budget as the answer, and the reasoning spend does not
         # depend on whether explanations were requested — an answers-only
@@ -483,18 +456,11 @@ def _completion_controls(
     }
 
 
-# Qwen3.7-max via Alibaba routinely needs more than 300s on the largest
-# households even at 3-variable chunks: six grind rounds (2026-07-06) left
-# the same ~36 scenarios timing out deterministically. Timeout is harness
-# infrastructure, not model configuration — the model still runs
-# unconfigured at its default reasoning effort.
-QWEN_REQUEST_TIMEOUT_SECONDS = 600
-
-
 def _request_timeout_seconds(model_id: str) -> int:
-    if model_id == "openrouter/qwen/qwen3.7-max":
-        return QWEN_REQUEST_TIMEOUT_SECONDS
-    if model_id in REASONING_DEFAULT_OPEN_WEIGHT_MODELS:
+    card = card_for(model_id)
+    if card is not None and card.request_timeout_seconds is not None:
+        return card.request_timeout_seconds
+    if card is not None and card.thinking_budget:
         return THINKING_CLAUDE_REQUEST_TIMEOUT_SECONDS
     if model_id.startswith("gemini/"):
         return GEMINI_REQUEST_TIMEOUT_SECONDS
@@ -553,27 +519,11 @@ def _run_request_with_wall_timeout(request_fn, request_kwargs: dict):
             signal.setitimer(signal.ITIMER_REAL, *previous_timer)
 
 
-# Models whose serving stack rejects or degrades forced tool calls. Moonshot
-# returns 400 "tool_choice 'specified' is incompatible with thinking enabled"
-# for Kimi K2.6 (OpenRouter then silently reroutes forced-tool requests to
-# third-party hosts where the model reasons to the token ceiling without ever
-# emitting the call), and Alibaba returns 400 "tool_choice ... does not
-# support being set to required ... in thinking mode" for Qwen3.7-max. The
-# JSON contract sidesteps tool_choice entirely.
-# GLM-5.2 accepts forced tool calls but reasons to the full 16,384-token
-# ceiling without emitting one (probed 2026-07-05); it gets the JSON contract
-# for the same reason.
-JSON_CONTRACT_MODELS = (
-    "openrouter/moonshotai/kimi-k2.6",
-    "openrouter/qwen/qwen3.7-max",
-    "openrouter/z-ai/glm-5.2",
-)
-
-
 def _answer_contract_for_model(model_id: str) -> str:
+    card = card_for(model_id)
+    if card is not None and card.answer_contract is not None:
+        return card.answer_contract
     if model_id.startswith("deepseek/") or model_id.startswith("gemini/"):
-        return "json"
-    if model_id in JSON_CONTRACT_MODELS:
         return "json"
     return "tool"
 

--- a/policybench/fold_board.py
+++ b/policybench/fold_board.py
@@ -1,0 +1,94 @@
+"""Fold new model prediction sets into an existing board for staging.
+
+Generalizes the one-off fold scripts used for the v1.x releases: takes the
+current board's combined predictions plus one predictions CSV per new model,
+enforces the row-count/duplicate gates that kept partial runs off the board,
+writes a scoring directory, and runs the standard country export so the
+staged ``summary_by_model.csv`` is ready to review.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+
+
+class FoldError(ValueError):
+    pass
+
+
+def _rows_per_model(base: pd.DataFrame) -> int:
+    counts = base.groupby("model").size()
+    if counts.nunique() != 1:
+        raise FoldError(
+            f"base board has unequal per-model row counts: {counts.to_dict()}"
+        )
+    return int(counts.iloc[0])
+
+
+def fold_board(
+    base_predictions: Path,
+    additions: list[Path],
+    scoring_source: Path,
+    out_dir: Path,
+    export: bool = True,
+) -> dict:
+    base = pd.read_csv(base_predictions)
+    expected_rows = _rows_per_model(base)
+
+    out_dir = Path(out_dir)
+    by_model_dir = out_dir / "by_model"
+    by_model_dir.mkdir(parents=True, exist_ok=True)
+
+    frames = [base]
+    folded: list[str] = []
+    excluded: dict[str, str] = {}
+    for path in additions:
+        frame = pd.read_csv(path)
+        models = frame["model"].unique()
+        if len(models) != 1:
+            excluded[str(path)] = f"expected one model, found {list(models)}"
+            continue
+        name = models[0]
+        dupes = int(frame.duplicated(["scenario_id", "variable"]).sum())
+        problems = []
+        if len(frame) != expected_rows:
+            problems.append(f"{len(frame)} rows (need {expected_rows})")
+        if dupes:
+            problems.append(f"{dupes} duplicate scenario/variable rows")
+        if name in set(base["model"]):
+            problems.append("model already on the base board")
+        if problems:
+            excluded[name] = "; ".join(problems)
+            continue
+        frame.to_csv(by_model_dir / f"{name}.csv", index=False)
+        frames.append(frame[base.columns])
+        folded.append(name)
+
+    combined = pd.concat(frames, ignore_index=True)
+    us_dir = out_dir / "us"
+    us_dir.mkdir(parents=True, exist_ok=True)
+    combined.to_csv(us_dir / "predictions.csv", index=False)
+    for name in ("reference_outputs.csv", "scenarios.csv", "scenarios.csv.meta.json"):
+        source = Path(scoring_source) / name
+        if source.exists():
+            (us_dir / name).write_bytes(source.read_bytes())
+
+    summary = None
+    if export:
+        from policybench.full_run_export import export_country
+
+        export_country(us_dir)
+        summary_path = us_dir / "analysis" / "summary_by_model.csv"
+        if summary_path.exists():
+            summary = pd.read_csv(summary_path)
+
+    return {
+        "folded": folded,
+        "excluded": excluded,
+        "models": int(combined["model"].nunique()),
+        "rows": len(combined),
+        "out_dir": str(out_dir),
+        "summary": summary,
+    }

--- a/policybench/model_cards.py
+++ b/policybench/model_cards.py
@@ -1,0 +1,111 @@
+"""Declarative per-model serving treatments.
+
+A ModelCard captures everything the harness must know about how one model's
+serving stack behaves: which answer contract it can honor, whether whole-
+scenario requests converge or need chunking, how long its slowest calls run,
+and whether reasoning-by-default token appetite needs the thinking-class
+completion budget. None of this is model *configuration* — every model still
+runs unconfigured at its provider-default reasoning effort. Cards only
+encode serving-stack facts discovered during onboarding (see
+``policybench onboard``).
+
+Cards OVERRIDE the family-prefix heuristics in ``eval_no_tools``; models
+without a card (or with a field left ``None``) keep the heuristic treatment.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class ModelCard:
+    litellm_id: str
+    # "tool" | "json" | None (None → family heuristic)
+    answer_contract: str | None = None
+    # Variables per request when explanations are on; None → no chunking
+    # unless the family heuristic chunks (Claude=1, gpt-5.5=3).
+    explanation_chunk_size: int | None = None
+    request_timeout_seconds: int | None = None
+    # True → 16,384-token completion budget on both explanation arms
+    # (reasoning bills against the same budget as the answer).
+    thinking_budget: bool | None = None
+    # Measured during onboarding; informs the run supervisor's projection
+    # before live per-scenario costs exist.
+    expected_cost_per_scenario_usd: float | None = None
+    notes: str = ""
+
+
+MODEL_CARDS: dict[str, ModelCard] = {
+    "gpt-5.5": ModelCard(
+        litellm_id="gpt-5.5",
+        explanation_chunk_size=3,
+        request_timeout_seconds=60,
+        thinking_budget=True,
+        notes=(
+            "Reasons at default (medium) effort; pre-#101 per-chunk budgets "
+            "truncated it at exactly the ceiling."
+        ),
+    ),
+    "deepseek/deepseek-v4-pro": ModelCard(
+        litellm_id="deepseek/deepseek-v4-pro",
+        answer_contract="json",
+        thinking_budget=True,
+        expected_cost_per_scenario_usd=0.011,
+        notes="Direct DeepSeek API; no cost field in responses.",
+    ),
+    "deepseek/deepseek-v4-flash": ModelCard(
+        litellm_id="deepseek/deepseek-v4-flash",
+        answer_contract="json",
+        thinking_budget=True,
+    ),
+    "openrouter/moonshotai/kimi-k2.6": ModelCard(
+        litellm_id="openrouter/moonshotai/kimi-k2.6",
+        answer_contract="json",
+        explanation_chunk_size=3,
+        thinking_budget=True,
+        expected_cost_per_scenario_usd=0.396,
+        notes=(
+            "Moonshot returns 400 for forced tool_choice with thinking "
+            "enabled; OpenRouter silently reroutes to hosts that reason to "
+            "the token ceiling. Whole-scenario JSON overflows into truncated "
+            "documents; converges at 3 variables/call."
+        ),
+    ),
+    "openrouter/z-ai/glm-5.2": ModelCard(
+        litellm_id="openrouter/z-ai/glm-5.2",
+        answer_contract="json",
+        explanation_chunk_size=3,
+        thinking_budget=True,
+        expected_cost_per_scenario_usd=0.09,
+        notes=(
+            "Reasons to the full ceiling on whole-scenario requests in both "
+            "contracts; converges at 3 variables/call."
+        ),
+    ),
+    "openrouter/minimax/minimax-m3": ModelCard(
+        litellm_id="openrouter/minimax/minimax-m3",
+        answer_contract="tool",
+        thinking_budget=True,
+        expected_cost_per_scenario_usd=0.02,
+        notes="Handles forced tool calls cleanly (12s / 926-token probe).",
+    ),
+    "openrouter/qwen/qwen3.7-max": ModelCard(
+        litellm_id="openrouter/qwen/qwen3.7-max",
+        answer_contract="json",
+        explanation_chunk_size=3,
+        request_timeout_seconds=600,
+        thinking_budget=True,
+        expected_cost_per_scenario_usd=0.129,
+        notes=(
+            "Alibaba returns 400 for tool_choice=required in thinking mode. "
+            "Largest households need >300s even at 3-variable chunks: six "
+            "grind rounds at 300s plateaued at 64/100; one 600s round "
+            "reached 93."
+        ),
+    ),
+}
+
+
+def card_for(model_id: str) -> ModelCard | None:
+    return MODEL_CARDS.get(model_id)

--- a/policybench/onboard.py
+++ b/policybench/onboard.py
@@ -1,0 +1,250 @@
+"""Onboarding gauntlet: probe a new model's serving stack, emit a ModelCard.
+
+Everything that cost debugging cycles during the 2026-07 open-weight
+expansion is a cheap, automatable probe:
+
+1. Forced tool call at 3 variables — Moonshot and Alibaba reject
+   ``tool_choice`` outright in thinking mode, and some marketplace hosts
+   accept it then reason to the token ceiling without emitting the call.
+2. JSON contract at 3 variables — the fallback contract.
+3. The surviving contract at 16 variables (whole-scenario shape) — GLM
+   reasoned to the ceiling here in both contracts; Kimi overflowed the JSON
+   document with its reasoning stream. Failure ⇒ chunk at 3.
+4. Latency and token appetite from the probes — models whose calls push the
+   default timeout get a larger one on the card, and measured cost per call
+   seeds the supervisor's budget projection.
+
+The result is a suggested ``ModelCard`` plus a probe log. Total cost is a
+few cents; run it before committing real money to a full benchmark.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from dataclasses import dataclass, field
+
+from litellm import completion
+
+from policybench import eval_no_tools as harness
+from policybench.model_cards import ModelCard
+
+PROBE_SMALL_VARIABLES = ["payroll_tax", "snap", "ssi"]
+PROBE_FULL_VARIABLE_COUNT = 16
+PROBE_TIMEOUT_SECONDS = 240
+# A call whose completion tokens hit the ceiling without producing a
+# parseable answer is the reason-to-the-ceiling signature.
+CEILING_FRACTION = 0.95
+# Probe latency above this fraction of the standard thinking-class timeout
+# earns an extended timeout on the card.
+SLOW_CALL_FRACTION = 0.5
+
+
+# Error text marking failures that say nothing about the serving stack —
+# probes hitting these abort the gauntlet instead of shaping the card.
+ENVIRONMENT_ERROR_MARKERS = (
+    "more credits",
+    "insufficient credits",
+    "402",
+    "authentication",
+    "invalid api key",
+    "api key not found",
+)
+
+
+@dataclass
+class ProbeResult:
+    name: str
+    ok: bool
+    seconds: float = 0.0
+    completion_tokens: int | None = None
+    finish_reason: str | None = None
+    parsed: int = 0
+    requested: int = 0
+    error: str | None = None
+    cost_usd: float | None = None
+
+    @property
+    def environment_error(self) -> bool:
+        if not self.error:
+            return False
+        lowered = self.error.lower()
+        return any(marker in lowered for marker in ENVIRONMENT_ERROR_MARKERS)
+
+
+@dataclass
+class GauntletReport:
+    model_id: str
+    probes: list[ProbeResult] = field(default_factory=list)
+    card: ModelCard | None = None
+    aborted: str | None = None
+
+    def to_dict(self) -> dict:
+        return {
+            "model_id": self.model_id,
+            "probes": [vars(p) for p in self.probes],
+            "card": vars(self.card) if self.card else None,
+            "aborted": self.aborted,
+        }
+
+
+def _probe_request(scenario, variables, model_id, contract):
+    """Build a harness-parity request forcing the given contract."""
+    messages, kwargs = harness._chat_completion_request_kwargs(
+        scenario, variables, model_id
+    )
+    kwargs.pop("caching", None)
+    kwargs["timeout"] = PROBE_TIMEOUT_SECONDS
+    if contract == "json":
+        for key in ("tools", "tool_choice"):
+            kwargs.pop(key, None)
+        prompt = harness.make_no_tools_batch_prompt(
+            scenario,
+            variables,
+            answer_contract="json",
+            include_explanations=True,
+        )
+        messages = [{"role": "user", "content": prompt}]
+    return messages, kwargs
+
+
+def _run_probe(name, scenario, variables, model_id, contract) -> ProbeResult:
+    messages, kwargs = _probe_request(scenario, variables, model_id, contract)
+    budget = kwargs.get("max_completion_tokens") or kwargs.get("max_tokens")
+    started = time.time()
+    try:
+        response = completion(
+            messages=messages, **{k: v for k, v in kwargs.items() if k != "messages"}
+        )
+    except Exception as error:
+        return ProbeResult(
+            name,
+            ok=False,
+            seconds=time.time() - started,
+            requested=len(variables),
+            error=f"{type(error).__name__}: {error}"[:300],
+        )
+    choice = response.choices[0]
+    message = choice.message
+    tool_calls = getattr(message, "tool_calls", None)
+    content = getattr(message, "content", None)
+    predictions = harness.extract_predictions(
+        content=content,
+        variables=variables,
+        tool_calls=tool_calls,
+        function_call=getattr(message, "function_call", None),
+    )
+    parsed = sum(1 for v in variables if predictions.get(v) is not None)
+    usage = getattr(response, "usage", None)
+    completion_tokens = getattr(usage, "completion_tokens", None)
+    cost = None
+    if usage is not None:
+        cost = getattr(usage, "cost", None)
+    hit_ceiling = (
+        budget is not None
+        and completion_tokens is not None
+        and completion_tokens >= budget * CEILING_FRACTION
+        and parsed == 0
+    )
+    return ProbeResult(
+        name,
+        ok=parsed == len(variables) and not hit_ceiling,
+        seconds=time.time() - started,
+        completion_tokens=completion_tokens,
+        finish_reason=choice.finish_reason,
+        parsed=parsed,
+        requested=len(variables),
+        cost_usd=cost,
+    )
+
+
+def run_gauntlet(model_id: str, scenario, full_variables: list[str]) -> GauntletReport:
+    """Probe one model and derive its suggested ModelCard.
+
+    ``scenario`` is any benchmark scenario; ``full_variables`` its expanded
+    output list (16+ entries exercises the whole-scenario request shape).
+    """
+    report = GauntletReport(model_id=model_id)
+
+    tool_small = _run_probe(
+        "tool-3var", scenario, PROBE_SMALL_VARIABLES, model_id, "tool"
+    )
+    report.probes.append(tool_small)
+    if tool_small.environment_error:
+        report.aborted = f"environment error, not a serving fact: {tool_small.error}"
+        return report
+    contract = "tool" if tool_small.ok else "json"
+    if not tool_small.ok:
+        json_small = _run_probe(
+            "json-3var", scenario, PROBE_SMALL_VARIABLES, model_id, "json"
+        )
+        report.probes.append(json_small)
+        if json_small.environment_error:
+            report.aborted = (
+                f"environment error, not a serving fact: {json_small.error}"
+            )
+            return report
+        if not json_small.ok:
+            # Neither contract answers a 3-variable request; nothing further
+            # to derive — the model cannot run the benchmark as-is.
+            return report
+
+    full_vars = full_variables[:PROBE_FULL_VARIABLE_COUNT]
+    full = _run_probe(f"{contract}-full", scenario, full_vars, model_id, contract)
+    report.probes.append(full)
+    if full.environment_error:
+        report.aborted = f"environment error, not a serving fact: {full.error}"
+        return report
+    chunk_size = None if full.ok else 3
+
+    slow = any(
+        p.seconds > harness.THINKING_CLAUDE_REQUEST_TIMEOUT_SECONDS * SLOW_CALL_FRACTION
+        for p in report.probes
+        if p.ok
+    )
+    timeout = 600 if slow else None
+
+    costs = [p.cost_usd for p in report.probes if p.cost_usd]
+    calls_per_scenario = 1 if chunk_size is None else 6
+    expected = round(sum(costs) / len(costs) * calls_per_scenario, 3) if costs else None
+
+    report.card = ModelCard(
+        litellm_id=model_id,
+        answer_contract=contract,
+        explanation_chunk_size=chunk_size,
+        request_timeout_seconds=timeout,
+        thinking_budget=True,
+        expected_cost_per_scenario_usd=expected,
+        notes="Derived by `policybench onboard` — verify with a 2-scenario smoke.",
+    )
+    return report
+
+
+def format_report(report: GauntletReport) -> str:
+    lines = [f"# Onboarding gauntlet: {report.model_id}", ""]
+    for probe in report.probes:
+        status = "PASS" if probe.ok else "FAIL"
+        detail = (
+            f"parsed {probe.parsed}/{probe.requested}"
+            if probe.error is None
+            else probe.error
+        )
+        lines.append(
+            f"- {probe.name}: {status} ({probe.seconds:.0f}s, "
+            f"tokens={probe.completion_tokens}, finish={probe.finish_reason}) "
+            f"— {detail}"
+        )
+    lines.append("")
+    if report.aborted:
+        lines.append(f"ABORTED — {report.aborted}")
+        lines.append("Fix the environment (credits, keys) and rerun; no card derived.")
+        return "\n".join(lines)
+    if report.card is None:
+        lines.append(
+            "No viable contract at 3 variables — the model cannot run the "
+            "benchmark without harness changes."
+        )
+    else:
+        lines.append("Suggested ModelCard (add to policybench/model_cards.py):")
+        lines.append(json.dumps(vars(report.card), indent=2))
+    return "\n".join(lines)

--- a/policybench/supervisor.py
+++ b/policybench/supervisor.py
@@ -1,0 +1,343 @@
+"""Run supervisor: a per-scenario work queue with a budget governor.
+
+Replaces the fixed-range worker pattern that made the 2026-07 open-weight
+runs painful: a slow scenario can no longer hold a 25-scenario range
+hostage, crashed workers cost one scenario's progress instead of a range,
+spend is projected from live per-scenario costs and the run stops cleanly
+at a budget threshold instead of dying in a 402 storm, and a heartbeat
+state file makes progress externally visible while worker stdout sits in
+block buffers.
+
+Each work item is ONE scenario, executed in its own subprocess through the
+existing sync CLI path — reusing the disk cache, repair rounds, and the
+SIGALRM wall timeout (which only functions on a process's main thread).
+Results land as one CSV per scenario under ``<run_dir>/scenarios/`` and are
+combined into ``<run_dir>/predictions.csv`` at the end; rerunning the same
+command skips completed scenarios and replays partially-complete ones from
+the response cache.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import pandas as pd
+
+from policybench.config import MODELS
+from policybench.model_cards import card_for
+
+HEARTBEAT_FILENAME = "run_state.json"
+SCENARIO_DIR = "scenarios"
+DEFAULT_MAX_WORKERS = 4
+MIN_WORKERS = 1
+# Above this timeout share in the sliding window, concurrency steps down.
+TIMEOUT_RATE_BACKOFF_THRESHOLD = 0.3
+ADAPTIVE_WINDOW = 8
+# Dispatching stops once projected spend for in-flight + queued work would
+# cross this share of the budget.
+BUDGET_STOP_FRACTION = 0.9
+
+
+@dataclass
+class ScenarioResult:
+    scenario_id: str
+    index: int
+    ok: bool
+    cost_usd: float = 0.0
+    rows: int = 0
+    missing_predictions: int = 0
+    timed_out: bool = False
+    seconds: float = 0.0
+
+
+@dataclass
+class RunState:
+    model: str
+    total: int
+    completed: list[str] = field(default_factory=list)
+    failed: dict[str, int] = field(default_factory=dict)
+    spent_usd: float = 0.0
+    budget_usd: float | None = None
+    workers: int = DEFAULT_MAX_WORKERS
+    stopped_reason: str | None = None
+    started_at: float = 0.0
+    updated_at: float = 0.0
+
+    def projected_total_usd(self) -> float | None:
+        if not self.completed:
+            return None
+        per = self.spent_usd / len(self.completed)
+        return per * self.total
+
+
+class Supervisor:
+    def __init__(
+        self,
+        model: str,
+        manifest: Path,
+        run_dir: Path,
+        budget_usd: float | None = None,
+        max_workers: int = DEFAULT_MAX_WORKERS,
+        max_rounds: int = 4,
+        python: str | None = None,
+        env: dict | None = None,
+    ):
+        self.model = model
+        self.litellm_id = MODELS.get(model, model)
+        self.manifest = Path(manifest)
+        self.run_dir = Path(run_dir)
+        self.budget_usd = budget_usd
+        self.max_workers = max_workers
+        self.max_rounds = max_rounds
+        self.python = python or sys.executable
+        self.env = {**os.environ, **(env or {})}
+        self.scenario_ids = self._load_scenario_ids()
+        self.state = RunState(
+            model=model,
+            total=len(self.scenario_ids),
+            budget_usd=budget_usd,
+            workers=min(max_workers, DEFAULT_MAX_WORKERS),
+        )
+        self._recent: list[ScenarioResult] = []
+        self.projection_warning: str | None = None
+
+    # -- setup -------------------------------------------------------------
+
+    def _load_scenario_ids(self) -> list[str]:
+        frame = pd.read_csv(self.manifest)
+        return list(frame["scenario_id"])
+
+    def scenario_csv(self, index: int) -> Path:
+        return self.run_dir / SCENARIO_DIR / f"scenario_{index:03d}.csv"
+
+    def _scenario_complete(self, index: int) -> bool:
+        path = self.scenario_csv(index)
+        if not path.exists():
+            return False
+        try:
+            frame = pd.read_csv(path)
+        except Exception:
+            return False
+        return len(frame) > 0 and set(frame["scenario_id"]) == {
+            self.scenario_ids[index]
+        }
+
+    def pending_indices(self) -> list[int]:
+        return [
+            i for i in range(len(self.scenario_ids)) if not self._scenario_complete(i)
+        ]
+
+    # -- budget ------------------------------------------------------------
+
+    def _spent_from_disk(self) -> float:
+        total = 0.0
+        scen_dir = self.run_dir / SCENARIO_DIR
+        if not scen_dir.exists():
+            return 0.0
+        for path in scen_dir.glob("scenario_*.csv"):
+            try:
+                frame = pd.read_csv(path)
+            except Exception:
+                continue
+            col = frame.get("total_cost_usd")
+            if col is not None:
+                total += float(col.fillna(0).sum())
+        return total
+
+    def budget_allows_dispatch(self) -> bool:
+        if self.budget_usd is None:
+            return True
+        if self.state.spent_usd >= self.budget_usd * BUDGET_STOP_FRACTION:
+            self.state.stopped_reason = (
+                f"budget: spent ${self.state.spent_usd:.2f} of "
+                f"${self.budget_usd:.2f} (stop at "
+                f"{BUDGET_STOP_FRACTION:.0%})"
+            )
+            return False
+        projected = self.state.projected_total_usd()
+        card = card_for(self.litellm_id)
+        if projected is None and card and card.expected_cost_per_scenario_usd:
+            projected = card.expected_cost_per_scenario_usd * self.state.total
+        if projected is not None and projected > self.budget_usd:
+            # Keep dispatching — partial coverage still monetizes via the
+            # response cache — but surface the projection immediately.
+            self.projection_warning = (
+                f"projected ${projected:.2f} exceeds budget ${self.budget_usd:.2f}"
+            )
+        return True
+
+    # -- adaptive concurrency ----------------------------------------------
+
+    def _record(self, result: ScenarioResult) -> None:
+        self._recent.append(result)
+        window = self._recent[-ADAPTIVE_WINDOW:]
+        timeout_rate = sum(1 for r in window if r.timed_out) / len(window)
+        if timeout_rate > TIMEOUT_RATE_BACKOFF_THRESHOLD:
+            self.state.workers = max(MIN_WORKERS, self.state.workers - 1)
+        elif (
+            len(window) == ADAPTIVE_WINDOW
+            and timeout_rate == 0
+            and self.state.workers < self.max_workers
+        ):
+            self.state.workers += 1
+
+    # -- heartbeat ----------------------------------------------------------
+
+    def write_heartbeat(self) -> None:
+        self.state.updated_at = time.time()
+        payload = {
+            "model": self.state.model,
+            "total": self.state.total,
+            "completed": len(self.state.completed),
+            "failed_counts": self.state.failed,
+            "spent_usd": round(self.state.spent_usd, 4),
+            "budget_usd": self.state.budget_usd,
+            "projected_total_usd": self.state.projected_total_usd(),
+            "workers": self.state.workers,
+            "stopped_reason": self.state.stopped_reason,
+            "projection_warning": self.projection_warning,
+            "started_at": self.state.started_at,
+            "updated_at": self.state.updated_at,
+        }
+        self.run_dir.mkdir(parents=True, exist_ok=True)
+        path = self.run_dir / HEARTBEAT_FILENAME
+        path.write_text(json.dumps(payload, indent=2))
+
+    # -- workers -------------------------------------------------------------
+
+    def _spawn(self, index: int) -> subprocess.Popen:
+        out = self.scenario_csv(index)
+        out.parent.mkdir(parents=True, exist_ok=True)
+        log = out.with_suffix(".log")
+        cmd = [
+            self.python,
+            "-m",
+            "policybench.cli",
+            "eval-no-tools",
+            "--model",
+            self.model,
+            "--scenario-manifest",
+            str(self.manifest),
+            "-n",
+            str(len(self.scenario_ids)),
+            "--scenario-start",
+            str(index),
+            "--scenario-end",
+            str(index + 1),
+            "-o",
+            str(out),
+        ]
+        return subprocess.Popen(
+            cmd,
+            stdout=open(log, "w"),
+            stderr=subprocess.STDOUT,
+            env=self.env,
+        )
+
+    def _collect(self, index: int, started: float) -> ScenarioResult:
+        scenario_id = self.scenario_ids[index]
+        path = self.scenario_csv(index)
+        if not path.exists():
+            return ScenarioResult(
+                scenario_id, index, ok=False, seconds=time.time() - started
+            )
+        try:
+            frame = pd.read_csv(path)
+        except Exception:
+            return ScenarioResult(
+                scenario_id, index, ok=False, seconds=time.time() - started
+            )
+        cost = float(
+            frame.get("total_cost_usd", pd.Series(dtype=float)).fillna(0).sum()
+        )
+        missing = int(frame["prediction"].isna().sum()) if "prediction" in frame else 0
+        log = path.with_suffix(".log")
+        timed_out = False
+        if log.exists():
+            text = log.read_text(errors="ignore")
+            timed_out = "Timeout" in text or "timed out" in text
+        return ScenarioResult(
+            scenario_id,
+            index,
+            ok=len(frame) > 0,
+            cost_usd=cost,
+            rows=len(frame),
+            missing_predictions=missing,
+            timed_out=timed_out,
+            seconds=time.time() - started,
+        )
+
+    # -- main loop -----------------------------------------------------------
+
+    def run(self, poll_seconds: float = 2.0) -> RunState:
+        self.state.started_at = time.time()
+        queue: list[int] = []
+        rounds: dict[int, int] = {}
+        for round_no in range(self.max_rounds):
+            pending = self.pending_indices()
+            if not pending:
+                break
+            queue = list(pending)
+            in_flight: dict[int, tuple[subprocess.Popen, float]] = {}
+            while queue or in_flight:
+                while (
+                    queue
+                    and len(in_flight) < self.state.workers
+                    and self.budget_allows_dispatch()
+                ):
+                    index = queue.pop(0)
+                    rounds[index] = rounds.get(index, 0) + 1
+                    in_flight[index] = (self._spawn(index), time.time())
+                if not in_flight:
+                    break  # budget stop with nothing running
+                time.sleep(poll_seconds)
+                for index in list(in_flight):
+                    proc, started = in_flight[index]
+                    if proc.poll() is None:
+                        continue
+                    del in_flight[index]
+                    result = self._collect(index, started)
+                    self._record(result)
+                    if result.ok:
+                        self.state.completed.append(result.scenario_id)
+                    else:
+                        self.state.failed[result.scenario_id] = rounds[index]
+                    self.state.spent_usd = self._spent_from_disk()
+                    self.write_heartbeat()
+            if self.state.stopped_reason:
+                break
+        self.state.spent_usd = self._spent_from_disk()
+        remaining = self.pending_indices()
+        if remaining and not self.state.stopped_reason:
+            self.state.stopped_reason = (
+                f"{len(remaining)} scenarios incomplete after {self.max_rounds} rounds"
+            )
+        self.write_heartbeat()
+        self.combine()
+        return self.state
+
+    # -- output ---------------------------------------------------------------
+
+    def combine(self) -> Path | None:
+        scen_dir = self.run_dir / SCENARIO_DIR
+        parts = sorted(scen_dir.glob("scenario_*.csv")) if scen_dir.exists() else []
+        if not parts:
+            return None
+        frames = []
+        for path in parts:
+            try:
+                frames.append(pd.read_csv(path))
+            except Exception:
+                continue
+        if not frames:
+            return None
+        combined = pd.concat(frames, ignore_index=True)
+        out = self.run_dir / "predictions.csv"
+        combined.to_csv(out, index=False)
+        return out

--- a/tests/test_fold_board.py
+++ b/tests/test_fold_board.py
@@ -1,0 +1,83 @@
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from policybench.fold_board import FoldError, fold_board
+
+
+def predictions(model: str, n_scenarios: int, rows_per_scenario: int = 2):
+    records = []
+    for i in range(n_scenarios):
+        for j in range(rows_per_scenario):
+            records.append(
+                {
+                    "model": model,
+                    "scenario_id": f"scenario_{i:03d}",
+                    "variable": f"var_{j}",
+                    "prediction": 1.0,
+                }
+            )
+    return pd.DataFrame(records)
+
+
+@pytest.fixture
+def board(tmp_path: Path):
+    base = pd.concat(
+        [predictions("model-a", 3), predictions("model-b", 3)], ignore_index=True
+    )
+    base_path = tmp_path / "base.csv"
+    base.to_csv(base_path, index=False)
+    scoring = tmp_path / "scoring"
+    scoring.mkdir()
+    (scoring / "reference_outputs.csv").write_text("scenario_id\n")
+    (scoring / "scenarios.csv").write_text("scenario_id\n")
+    return base_path, scoring
+
+
+def test_folds_complete_model(board, tmp_path):
+    base_path, scoring = board
+    add = tmp_path / "new.csv"
+    predictions("model-c", 3).to_csv(add, index=False)
+    result = fold_board(base_path, [add], scoring, tmp_path / "out", export=False)
+    assert result["folded"] == ["model-c"]
+    assert result["models"] == 3
+    combined = pd.read_csv(tmp_path / "out" / "us" / "predictions.csv")
+    assert combined.model.nunique() == 3
+    assert (tmp_path / "out" / "by_model" / "model-c.csv").exists()
+    assert (tmp_path / "out" / "us" / "reference_outputs.csv").exists()
+
+
+def test_excludes_short_run(board, tmp_path):
+    base_path, scoring = board
+    add = tmp_path / "short.csv"
+    predictions("model-c", 2).to_csv(add, index=False)
+    result = fold_board(base_path, [add], scoring, tmp_path / "out", export=False)
+    assert result["folded"] == []
+    assert "4 rows (need 6)" in result["excluded"]["model-c"]
+    assert result["models"] == 2
+
+
+def test_excludes_duplicates_and_existing_model(board, tmp_path):
+    base_path, scoring = board
+    dupes = predictions("model-c", 3)
+    dupes = pd.concat([dupes, dupes.iloc[:1]], ignore_index=True)
+    dupes_path = tmp_path / "dupes.csv"
+    dupes.to_csv(dupes_path, index=False)
+    existing = tmp_path / "existing.csv"
+    predictions("model-a", 3).to_csv(existing, index=False)
+    result = fold_board(
+        base_path, [dupes_path, existing], scoring, tmp_path / "out", export=False
+    )
+    assert result["folded"] == []
+    assert "duplicate" in result["excluded"]["model-c"]
+    assert "already on the base board" in result["excluded"]["model-a"]
+
+
+def test_unbalanced_base_raises(board, tmp_path):
+    base_path, scoring = board
+    frame = pd.read_csv(base_path)
+    frame = pd.concat([frame, frame.iloc[:1]], ignore_index=True)
+    frame.to_csv(base_path, index=False)
+    with pytest.raises(FoldError, match="unequal per-model row counts"):
+        fold_board(base_path, [], scoring, tmp_path / "out", export=False)

--- a/tests/test_model_cards.py
+++ b/tests/test_model_cards.py
@@ -1,0 +1,72 @@
+"""Locks every roster model's serving treatment.
+
+The model-card registry replaced scattered per-model tuples; this table is
+the single place that records what each model's treatment IS. A failure here
+means a card or heuristic changed a live model's treatment — fine if
+deliberate, but it must show up in the diff of this file too.
+"""
+
+import pytest
+
+from policybench.config import MODELS
+from policybench.eval_no_tools import (
+    _answer_contract_for_model,
+    _completion_controls,
+    _request_timeout_seconds,
+    _required_explanation_chunk_size,
+)
+
+# model_id -> (contract, chunk_size, timeout_s, budget_for_16_vars_with_expl)
+EXPECTED = {
+    "gpt-5.5": ("tool", 3, 60, 16_384),
+    "claude-fable-5": ("tool", 1, 300, 16_384),
+    "claude-sonnet-5": ("tool", 1, 300, 16_384),
+    "claude-opus-4-8": ("tool", 1, 120, 4_096),
+    "claude-opus-4-7": ("tool", 1, 120, 4_096),
+    "claude-sonnet-4-6": ("tool", 1, 120, 4_096),
+    "claude-haiku-4-5-20251001": ("tool", 1, 120, 4_096),
+    "gemini/gemini-3.1-pro-preview": ("json", None, 120, 16_384),
+    "gemini/gemini-3-flash-preview": ("json", None, 120, 16_384),
+    "gemini/gemini-3.5-flash": ("json", None, 120, 16_384),
+    "gemini/gemini-3.1-flash-lite-preview": ("json", None, 120, 16_384),
+    "gpt-5.4-mini": ("tool", None, 20, 4_096),
+    "gpt-5.4-nano": ("tool", None, 20, 4_096),
+    "xai/grok-4.3": ("tool", None, 420, 4_096),
+    "xai/grok-build-0.1": ("tool", None, 420, 4_096),
+    "deepseek/deepseek-v4-pro": ("json", None, 300, 16_384),
+    "deepseek/deepseek-v4-flash": ("json", None, 300, 16_384),
+    "openrouter/moonshotai/kimi-k2.6": ("json", 3, 300, 16_384),
+    "openrouter/z-ai/glm-5.2": ("json", 3, 300, 16_384),
+    "openrouter/minimax/minimax-m3": ("tool", None, 300, 16_384),
+    "openrouter/qwen/qwen3.7-max": ("json", 3, 600, 16_384),
+}
+
+
+def _budget(model_id: str) -> int:
+    controls = _completion_controls(
+        model_id, include_explanations=True, variables=[f"v{i}" for i in range(16)]
+    )
+    return (
+        controls.get("max_completion_tokens")
+        or controls.get("max_tokens")
+        or controls.get("max_output_tokens")
+    )
+
+
+def test_every_roster_model_has_an_expected_treatment():
+    missing = set(MODELS.values()) - set(EXPECTED)
+    assert not missing, f"add treatments for: {sorted(missing)}"
+
+
+@pytest.mark.parametrize("model_id", sorted(EXPECTED))
+def test_treatment_locked(model_id):
+    contract, chunk, timeout, budget = EXPECTED[model_id]
+    assert _answer_contract_for_model(model_id) == contract
+    assert _required_explanation_chunk_size(model_id, True) == chunk
+    assert _request_timeout_seconds(model_id) == timeout
+    assert _budget(model_id) == budget
+
+
+def test_no_chunking_when_explanations_off():
+    for model_id in EXPECTED:
+        assert _required_explanation_chunk_size(model_id, False) is None

--- a/tests/test_onboard.py
+++ b/tests/test_onboard.py
@@ -1,0 +1,163 @@
+"""Gauntlet decision-tree tests with mocked provider responses."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from policybench.onboard import format_report, run_gauntlet
+from policybench.scenarios import generate_scenarios
+
+FULL_VARS = [f"var_{i}" for i in range(16)]
+
+
+@pytest.fixture(scope="module")
+def scenario():
+    return generate_scenarios(n=1, seed=0)[0]
+
+
+def fake_response(
+    variables=None, tokens=200, finish="stop", tool_call=True, empty=False
+):
+    if empty:
+        message = SimpleNamespace(content=None, tool_calls=None, function_call=None)
+    elif tool_call:
+        import json
+
+        arguments = json.dumps(
+            {"outputs": {v: {"value": 1, "explanation": "x"} for v in variables}}
+        )
+        call = SimpleNamespace(
+            function=SimpleNamespace(name="submit_outputs", arguments=arguments)
+        )
+        message = SimpleNamespace(content=None, tool_calls=[call], function_call=None)
+    else:
+        import json
+
+        content = json.dumps(
+            {"outputs": {v: {"value": 1, "explanation": "x"} for v in variables}}
+        )
+        message = SimpleNamespace(content=content, tool_calls=None, function_call=None)
+    return SimpleNamespace(
+        choices=[SimpleNamespace(message=message, finish_reason=finish)],
+        usage=SimpleNamespace(completion_tokens=tokens, cost=0.002),
+    )
+
+
+def test_clean_tool_model_gets_tool_contract(scenario):
+    def respond(messages, **kwargs):
+        tools = kwargs.get("tools")
+        variables = (
+            list(
+                tools[0]["function"]["parameters"]["properties"]["outputs"][
+                    "properties"
+                ]
+            )
+            if tools
+            else FULL_VARS
+        )
+        return fake_response(variables=variables, tool_call=bool(tools))
+
+    with patch("policybench.onboard.completion", side_effect=respond):
+        report = run_gauntlet("openrouter/example/clean", scenario, FULL_VARS)
+    assert report.card.answer_contract == "tool"
+    assert report.card.explanation_chunk_size is None
+    assert report.card.request_timeout_seconds is None
+
+
+def test_tool_rejection_falls_to_json(scenario):
+    def respond(messages, **kwargs):
+        if kwargs.get("tools"):
+            raise RuntimeError("tool_choice incompatible with thinking")
+        return fake_response(variables=_requested(messages), tool_call=False)
+
+    def _requested(messages):
+        text = messages[0]["content"]
+        return [v for v in (FULL_VARS + ["payroll_tax", "snap", "ssi"]) if v in text]
+
+    with patch("policybench.onboard.completion", side_effect=respond):
+        report = run_gauntlet("openrouter/example/no-tools", scenario, FULL_VARS)
+    assert report.card.answer_contract == "json"
+    names = [p.name for p in report.probes]
+    assert names == ["tool-3var", "json-3var", "json-full"]
+
+
+def test_ceiling_burn_on_full_probe_triggers_chunking(scenario):
+    calls = {"n": 0}
+
+    def respond(messages, **kwargs):
+        calls["n"] += 1
+        text = messages[0]["content"]
+        requested = [
+            v for v in (FULL_VARS + ["payroll_tax", "snap", "ssi"]) if v in text
+        ]
+        if len(requested) > 3:
+            return fake_response(tokens=16_384, finish="length", empty=True)
+        return fake_response(variables=requested, tool_call=bool(kwargs.get("tools")))
+
+    with patch("policybench.onboard.completion", side_effect=respond):
+        report = run_gauntlet("openrouter/example/burner", scenario, FULL_VARS)
+    assert report.card.explanation_chunk_size == 3
+    assert report.card.expected_cost_per_scenario_usd is not None
+
+
+def test_no_viable_contract_yields_no_card(scenario):
+    def respond(messages, **kwargs):
+        raise RuntimeError("nope")
+
+    with patch("policybench.onboard.completion", side_effect=respond):
+        report = run_gauntlet("openrouter/example/dead", scenario, FULL_VARS)
+    assert report.card is None
+    assert "cannot run the benchmark" in format_report(report)
+
+
+def test_slow_probes_earn_extended_timeout(scenario):
+    clock = {"t": 0.0}
+
+    def fake_time():
+        clock["t"] += 200.0
+        return clock["t"]
+
+    def respond(messages, **kwargs):
+        tools = kwargs.get("tools")
+        variables = (
+            list(
+                tools[0]["function"]["parameters"]["properties"]["outputs"][
+                    "properties"
+                ]
+            )
+            if tools
+            else FULL_VARS
+        )
+        return fake_response(variables=variables, tool_call=bool(tools))
+
+    with (
+        patch("policybench.onboard.completion", side_effect=respond),
+        patch("policybench.onboard.time.time", side_effect=fake_time),
+    ):
+        report = run_gauntlet("openrouter/example/slow", scenario, FULL_VARS)
+    assert report.card.request_timeout_seconds == 600
+
+
+def test_credit_errors_abort_without_card(scenario):
+    def respond(messages, **kwargs):
+        if kwargs.get("tools"):
+            variables = list(
+                kwargs["tools"][0]["function"]["parameters"]["properties"]["outputs"][
+                    "properties"
+                ]
+            )
+            if len(variables) > 3:
+                raise RuntimeError(
+                    "This request requires more credits, or fewer max_tokens."
+                )
+            return fake_response(variables=variables, tool_call=True)
+        return fake_response(variables=FULL_VARS, tool_call=False)
+
+    with patch("policybench.onboard.completion", side_effect=respond):
+        report = run_gauntlet("openrouter/example/broke", scenario, FULL_VARS)
+    assert report.card is None
+    assert "environment error" in report.aborted
+    assert "no card derived" in format_report(report)

--- a/tests/test_onboard.py
+++ b/tests/test_onboard.py
@@ -8,14 +8,21 @@ from unittest.mock import patch
 import pytest
 
 from policybench.onboard import format_report, run_gauntlet
-from policybench.scenarios import generate_scenarios
+from policybench.scenarios import Person, Scenario
 
 FULL_VARS = [f"var_{i}" for i in range(16)]
 
 
 @pytest.fixture(scope="module")
 def scenario():
-    return generate_scenarios(n=1, seed=0)[0]
+    # Synthetic scenario: generate_scenarios() loads the certified populace
+    # frame, which is far too heavy for CI runners.
+    return Scenario(
+        id="scenario_000",
+        state="CA",
+        filing_status="SINGLE",
+        adults=[Person(name="adult_1", age=35, employment_income=30_000.0)],
+    )
 
 
 def fake_response(

--- a/tests/test_supervisor.py
+++ b/tests/test_supervisor.py
@@ -1,0 +1,152 @@
+"""Supervisor unit tests — no live subprocesses or API calls.
+
+Workers are stubbed with instantly-exiting processes; scenario CSVs are
+synthesized by the stub so the queue, resume, budget-governor, adaptive-
+concurrency, and combine behaviors are exercised on real files.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from policybench.supervisor import (
+    ADAPTIVE_WINDOW,
+    BUDGET_STOP_FRACTION,
+    DEFAULT_MAX_WORKERS,
+    ScenarioResult,
+    Supervisor,
+)
+
+N_SCENARIOS = 6
+
+
+@pytest.fixture
+def manifest(tmp_path: Path) -> Path:
+    path = tmp_path / "scenarios.csv"
+    pd.DataFrame(
+        {"scenario_id": [f"scenario_{i:03d}" for i in range(N_SCENARIOS)]}
+    ).to_csv(path, index=False)
+    return path
+
+
+def make_supervisor(manifest: Path, tmp_path: Path, **kwargs) -> Supervisor:
+    return Supervisor(
+        model="test-model",
+        manifest=manifest,
+        run_dir=tmp_path / "run",
+        **kwargs,
+    )
+
+
+def stub_worker(
+    supervisor: Supervisor,
+    monkeypatch,
+    cost_per_scenario: float = 0.1,
+    fail_indices: set[int] | None = None,
+    timeout_indices: set[int] | None = None,
+):
+    """Replace _spawn with a no-op process and synthesize the scenario CSV."""
+    fail_indices = fail_indices or set()
+    timeout_indices = timeout_indices or set()
+
+    def fake_spawn(index: int):
+        if index not in fail_indices:
+            out = supervisor.scenario_csv(index)
+            out.parent.mkdir(parents=True, exist_ok=True)
+            pd.DataFrame(
+                {
+                    "scenario_id": [supervisor.scenario_ids[index]] * 2,
+                    "prediction": [1.0, 2.0],
+                    "total_cost_usd": [cost_per_scenario / 2] * 2,
+                }
+            ).to_csv(out, index=False)
+        if index in timeout_indices:
+            log = supervisor.scenario_csv(index).with_suffix(".log")
+            log.parent.mkdir(parents=True, exist_ok=True)
+            log.write_text("litellm.Timeout: Connection timed out")
+        return subprocess.Popen(["true"])
+
+    monkeypatch.setattr(supervisor, "_spawn", fake_spawn)
+
+
+def test_happy_path_completes_all_and_combines(manifest, tmp_path, monkeypatch):
+    supervisor = make_supervisor(manifest, tmp_path)
+    stub_worker(supervisor, monkeypatch)
+    state = supervisor.run(poll_seconds=0.01)
+    assert len(state.completed) == N_SCENARIOS
+    assert state.stopped_reason is None
+    combined = pd.read_csv(supervisor.run_dir / "predictions.csv")
+    assert combined.scenario_id.nunique() == N_SCENARIOS
+    heartbeat = json.loads((supervisor.run_dir / "run_state.json").read_text())
+    assert heartbeat["completed"] == N_SCENARIOS
+
+
+def test_resume_skips_completed_scenarios(manifest, tmp_path, monkeypatch):
+    supervisor = make_supervisor(manifest, tmp_path)
+    stub_worker(supervisor, monkeypatch)
+    for index in (0, 1):
+        supervisor._spawn(index).wait()
+    spawned: list[int] = []
+    original = supervisor._spawn
+
+    def tracking_spawn(index: int):
+        spawned.append(index)
+        return original(index)
+
+    monkeypatch.setattr(supervisor, "_spawn", tracking_spawn)
+    supervisor.run(poll_seconds=0.01)
+    assert 0 not in spawned and 1 not in spawned
+    assert sorted(spawned) == [2, 3, 4, 5]
+
+
+def test_failed_scenarios_retry_up_to_max_rounds(manifest, tmp_path, monkeypatch):
+    supervisor = make_supervisor(manifest, tmp_path, max_rounds=3)
+    stub_worker(supervisor, monkeypatch, fail_indices={4})
+    state = supervisor.run(poll_seconds=0.01)
+    assert len(state.completed) == N_SCENARIOS - 1
+    assert "scenario_004" in state.failed
+    assert state.failed["scenario_004"] == 3
+    assert "incomplete" in state.stopped_reason
+
+
+def test_budget_governor_stops_dispatching(manifest, tmp_path, monkeypatch):
+    supervisor = make_supervisor(manifest, tmp_path, budget_usd=0.3, max_workers=1)
+    stub_worker(supervisor, monkeypatch, cost_per_scenario=0.1)
+    state = supervisor.run(poll_seconds=0.01)
+    assert state.stopped_reason and state.stopped_reason.startswith("budget")
+    assert len(state.completed) < N_SCENARIOS
+    assert state.spent_usd >= 0.3 * BUDGET_STOP_FRACTION
+
+
+def test_projection_warning_from_card_estimate(manifest, tmp_path, monkeypatch):
+    supervisor = make_supervisor(manifest, tmp_path, budget_usd=100.0)
+    monkeypatch.setattr(
+        "policybench.supervisor.card_for",
+        lambda _mid: type("Card", (), {"expected_cost_per_scenario_usd": 50.0})(),
+    )
+    assert supervisor.budget_allows_dispatch()
+    assert "projected $300.00 exceeds budget $100.00" in supervisor.projection_warning
+
+
+def test_adaptive_backoff_and_recovery(manifest, tmp_path):
+    supervisor = make_supervisor(manifest, tmp_path, max_workers=6)
+    supervisor.state.workers = 4
+    for _ in range(ADAPTIVE_WINDOW):
+        supervisor._record(ScenarioResult("s", 0, ok=False, timed_out=True))
+    assert supervisor.state.workers < 4
+    supervisor._recent.clear()
+    supervisor.state.workers = 4
+    for _ in range(ADAPTIVE_WINDOW):
+        supervisor._record(ScenarioResult("s", 0, ok=True))
+    assert supervisor.state.workers == 5
+
+
+def test_default_worker_cap(manifest, tmp_path):
+    supervisor = make_supervisor(manifest, tmp_path, max_workers=12)
+    assert supervisor.state.workers == DEFAULT_MAX_WORKERS
+    assert supervisor.max_workers == 12


### PR DESCRIPTION
## Summary

Turns the lessons of the 2026-07-05/06 open-weight expansion (three days, three credit exhaustions, two zsh launch failures, one concurrency collapse, ~19 hours of range-workers hostage to slow scenarios) into infrastructure:

**`policybench/model_cards.py`** — every per-model serving treatment (answer contract, chunking, timeout, thinking-class budget) in one declarative registry; family-prefix heuristics remain the fallback. `tests/test_model_cards.py` locks all 21 roster treatments so changes always appear in a diff.

**`policybench run`** — supervised benchmark runs:
- per-scenario work queue; a slow household delays one worker-slot, not a 25-scenario range
- process-per-scenario workers through the existing sync CLI (same disk cache, repair rounds, SIGALRM wall timeout)
- adaptive concurrency: backs off when the timeout rate spikes, recovers when clean
- budget governor: projects total spend from live per-scenario costs (seeded by the model card estimate), warns immediately when projection exceeds budget, stops dispatching cleanly at 90% instead of dying in a 402 storm
- `run_state.json` heartbeat for external visibility; rerunning the same command resumes losslessly

**`policybench onboard`** — the probe gauntlet: forced-tool vs JSON at 3 variables, the surviving contract at 16 (the whole-scenario shape that broke kimi/GLM/qwen), latency and cost measurement → suggested ModelCard. Funding/auth errors abort with "fix the environment" rather than deriving a card from noise. Live-validated against minimax-m3 (correctly derived its tool contract; caught the credit-exhaustion case in the same run).

**`policybench fold-board`** — the release fold generalized, with the row-count/duplicate/already-on-board gates.

446 tests pass (40 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
