### PR TITLE
Meter supervisor spend by provider credits delta

### DIFF
--- a/policybench/supervisor.py
+++ b/policybench/supervisor.py
@@ -24,6 +24,7 @@ import os
 import subprocess
 import sys
 import time
+import urllib.request
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -106,6 +107,9 @@ class Supervisor:
         )
         self._recent: list[ScenarioResult] = []
         self.projection_warning: str | None = None
+        self._credits_baseline = self._credits_usage()
+        self._credits_checked_at = float("-inf")
+        self._credits_spent = 0.0
 
     # -- setup -------------------------------------------------------------
 
@@ -134,6 +138,43 @@ class Supervisor:
         ]
 
     # -- budget ------------------------------------------------------------
+
+    # Cache-replayed responses carry their ORIGINAL recorded cost, so the
+    # disk sum double-counts money spent in earlier runs (observed on the
+    # supervisor's first production outing: $7.74 "spent" in a minute of
+    # free replays). When an OpenRouter key is present, the /credits delta
+    # from run start is the authoritative meter; the disk sum is the
+    # fallback for providers without a balance endpoint.
+    CREDITS_POLL_SECONDS = 20.0
+
+    def _credits_usage(self) -> float | None:
+        key = self.env.get("OPENROUTER_API_KEY")
+        if not key:
+            return None
+        request = urllib.request.Request(
+            "https://openrouter.ai/api/v1/credits",
+            headers={"Authorization": f"Bearer {key}"},
+        )
+        try:
+            with urllib.request.urlopen(request, timeout=10) as response:
+                data = json.load(response)["data"]
+            return float(data["total_usage"])
+        except Exception:
+            return None
+
+    def _spent(self) -> float:
+        now = time.monotonic()
+        if (
+            self._credits_baseline is not None
+            and now - self._credits_checked_at >= self.CREDITS_POLL_SECONDS
+        ):
+            usage = self._credits_usage()
+            self._credits_checked_at = now
+            if usage is not None:
+                self._credits_spent = max(0.0, usage - self._credits_baseline)
+        if self._credits_baseline is not None:
+            return self._credits_spent
+        return self._spent_from_disk()
 
     def _spent_from_disk(self) -> float:
         total = 0.0
@@ -308,11 +349,11 @@ class Supervisor:
                         self.state.completed.append(result.scenario_id)
                     else:
                         self.state.failed[result.scenario_id] = rounds[index]
-                    self.state.spent_usd = self._spent_from_disk()
+                    self.state.spent_usd = self._spent()
                     self.write_heartbeat()
             if self.state.stopped_reason:
                 break
-        self.state.spent_usd = self._spent_from_disk()
+        self.state.spent_usd = self._spent()
         remaining = self.pending_indices()
         if remaining and not self.state.stopped_reason:
             self.state.stopped_reason = (

--- a/tests/test_supervisor.py
+++ b/tests/test_supervisor.py
@@ -150,3 +150,29 @@ def test_default_worker_cap(manifest, tmp_path):
     supervisor = make_supervisor(manifest, tmp_path, max_workers=12)
     assert supervisor.state.workers == DEFAULT_MAX_WORKERS
     assert supervisor.max_workers == 12
+
+
+def test_spend_prefers_credits_delta_over_disk(manifest, tmp_path, monkeypatch):
+    usage = {"value": 100.0}
+    monkeypatch.setattr(Supervisor, "_credits_usage", lambda self: usage["value"])
+    supervisor = make_supervisor(manifest, tmp_path)
+    assert supervisor._credits_baseline == 100.0
+    # Replayed scenarios put stale cost on disk; the meter must ignore it.
+    stub = tmp_path / "run" / "scenarios"
+    stub.mkdir(parents=True)
+    pd.DataFrame(
+        {"scenario_id": ["scenario_000"], "prediction": [1.0], "total_cost_usd": [9.9]}
+    ).to_csv(stub / "scenario_000.csv", index=False)
+    usage["value"] = 100.5
+    assert supervisor._spent() == pytest.approx(0.5)
+
+
+def test_spend_falls_back_to_disk_without_credits(manifest, tmp_path, monkeypatch):
+    monkeypatch.setattr(Supervisor, "_credits_usage", lambda self: None)
+    supervisor = make_supervisor(manifest, tmp_path)
+    stub = tmp_path / "run" / "scenarios"
+    stub.mkdir(parents=True)
+    pd.DataFrame(
+        {"scenario_id": ["scenario_000"], "prediction": [1.0], "total_cost_usd": [0.7]}
+    ).to_csv(stub / "scenario_000.csv", index=False)
+    assert supervisor._spent() == pytest.approx(0.7)


### PR DESCRIPTION
Cache replays carry their original recorded cost; summing scenario CSVs double-counts prior runs' spend (observed: $7.74 'spent' in one minute of free replays, which would have tripped the budget governor on phantom spend). Prefer the OpenRouter /credits delta from run start when a key is present; keep the disk sum as fallback. Two new tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)