### PR TITLE
Give Kimi K2.6 the 600s request timeout

### DIFF
--- a/policybench/model_cards.py
+++ b/policybench/model_cards.py
@@ -63,6 +63,7 @@ MODEL_CARDS: dict[str, ModelCard] = {
         litellm_id="openrouter/moonshotai/kimi-k2.6",
         answer_contract="json",
         explanation_chunk_size=3,
+        request_timeout_seconds=600,
         thinking_budget=True,
         expected_cost_per_scenario_usd=0.396,
         notes=(

--- a/tests/test_model_cards.py
+++ b/tests/test_model_cards.py
@@ -35,7 +35,7 @@ EXPECTED = {
     "xai/grok-build-0.1": ("tool", None, 420, 4_096),
     "deepseek/deepseek-v4-pro": ("json", None, 300, 16_384),
     "deepseek/deepseek-v4-flash": ("json", None, 300, 16_384),
-    "openrouter/moonshotai/kimi-k2.6": ("json", 3, 300, 16_384),
+    "openrouter/moonshotai/kimi-k2.6": ("json", 3, 600, 16_384),
     "openrouter/z-ai/glm-5.2": ("json", 3, 300, 16_384),
     "openrouter/minimax/minimax-m3": ("tool", None, 300, 16_384),
     "openrouter/qwen/qwen3.7-max": ("json", 3, 600, 16_384),


### PR DESCRIPTION
scenario_109's chunks exceed 300s deterministically (nine attempts across two days); one pass at 600s completed it — the same largest-household signature that earned qwen its 600s. Lock table updated. With this, kimi finishes 100/100 and the 20-model board is complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)