### PR TITLE
Make the failure-audit judge diagnose decisively per model

### DIFF
--- a/policybench/audit.py
+++ b/policybench/audit.py
@@ -20,6 +20,7 @@ LLM step is the only non-deterministic link and is fully resumable.
 from __future__ import annotations
 
 import json
+import re
 import shutil
 from dataclasses import asdict, dataclass
 from pathlib import Path
@@ -63,6 +64,7 @@ class AuditCase:
     reference_derivation: str
     question: str
     wrong_models: tuple[WrongModel, ...]
+    grounding: str = ""
 
     def to_manifest_row(self) -> dict:
         row = asdict(self)
@@ -81,8 +83,16 @@ def _case_id(country: str, scenario_id: str, variable: str) -> str:
     return "".join(c if (c.isalnum() or c in "._-") else "-" for c in safe)
 
 
-def build_audit_cases(country_dir: Path) -> list[AuditCase]:
-    """Assemble one :class:`AuditCase` per wrong ``(scenario_id, variable)``."""
+def build_audit_cases(
+    country_dir: Path,
+    grounding_lookup: dict[tuple[str, str], str] | None = None,
+) -> list[AuditCase]:
+    """Assemble one :class:`AuditCase` per wrong ``(scenario_id, variable)``.
+
+    ``grounding_lookup`` optionally maps ``(scenario_id, variable)`` to a block
+    of authoritative engine facts (e.g. the Medicaid eligibility category from
+    the reference trace) rendered into the case prompt.
+    """
     country = country_dir.name
     wrong = wrong_prediction_rows(country_dir)
     if wrong.empty:
@@ -133,6 +143,9 @@ def build_audit_cases(country_dir: Path) -> list[AuditCase]:
                 ),
                 question=questions.get((str(scenario_id), str(variable)), ""),
                 wrong_models=wrong_models,
+                grounding=(grounding_lookup or {}).get(
+                    (str(scenario_id), str(variable)), ""
+                ),
             )
         )
     return cases
@@ -201,7 +214,12 @@ AUDIT_OUTPUT_SCHEMA: dict = {
         },
         "rationale": {
             "type": "string",
-            "description": "2-4 sentence explanation of the classification.",
+            "description": (
+                "2-4 sentences on the shared trap: the specific rule or "
+                "computation step that separates the reference from the wrong "
+                "answers in this case. Definitive voice; never discuss "
+                "whether the reference is correct here."
+            ),
         },
         "models": {
             "type": "array",
@@ -218,8 +236,25 @@ AUDIT_OUTPUT_SCHEMA: dict = {
                         "type": "string",
                         "enum": list(FAILURE_SUBTYPE_VALUES),
                     },
+                    "diagnosis": {
+                        "type": "string",
+                        "description": (
+                            "1-3 definitive sentences: the exact rule, "
+                            "eligibility pathway, deduction, threshold, or "
+                            "computation step THIS model missed or "
+                            "misapplied, grounded in its own stated "
+                            "reasoning (or, absent reasoning, in what its "
+                            "answer implies it computed). No hedging; never "
+                            "discuss whether the reference is correct."
+                        ),
+                    },
                 },
-                "required": ["model", "failure_source", "failure_subtype"],
+                "required": [
+                    "model",
+                    "failure_source",
+                    "failure_subtype",
+                    "diagnosis",
+                ],
             },
         },
     },
@@ -234,30 +269,54 @@ AUDIT_OUTPUT_SCHEMA: dict = {
 }
 
 _PROMPT_HEADER = """\
-You are auditing why AI models missed a PolicyEngine reference value on a \
+You are diagnosing why AI models missed a PolicyEngine reference value on a \
 US/UK tax-and-benefit estimation benchmark. The models answered from \
 parametric knowledge with no tools; PolicyEngine's microsimulation is the \
-reference. Classify the failure for this one case.
+reference.
 
-Decide, conservatively:
-1. Is the PolicyEngine REFERENCE itself likely wrong (a model/data bug worth \
-filing upstream)? Set reference_suspect=true ONLY with concrete evidence \
-(e.g. the reference contradicts the stated rules, or every model agrees on a \
-value that is clearly correct against the law). Default to false — the models \
-are usually the ones in error.
-2. Otherwise, classify each model's miss into a failure_subtype, and give the \
-case a primary failure_source/subtype.
+The reference value and its derivation are generated directly from the \
+engine's computation trace, and the reference pipeline has survived an \
+adversarial review program: every wrong-reference hypothesis raised by \
+earlier audits was adjudicated against primary sources, and the few real \
+bugs found were fixed before this run. Treat the reference and its \
+derivation as correct. Your job is NOT to re-litigate the reference — it is \
+to explain each model's mistake decisively.
+
+For every wrong model, write a `diagnosis`: 1-3 definitive sentences naming \
+the exact rule, eligibility pathway, deduction, threshold, or computation \
+step that model missed or misapplied, grounded in its own stated reasoning. \
+Be specific — "treated the 138% FPL MAGI limit as the only Medicaid pathway \
+and never applied the aged/disabled income test, which deducts the Medicare \
+Part B premium from countable income" — not generic ("got the income \
+calculation wrong"). If the model gave no usable reasoning, derive the \
+mistake from its answer: state what the correct derivation yields and what \
+shortcut the model's number is consistent with.
+
+Hedging is forbidden in `diagnosis` and `rationale`, and these phrasings \
+are mechanically rejected: "plausible"; "not enough evidence"; \
+"insufficient evidence/information"; "cannot/unable to \
+determine/verify/confirm/tell"; "difficult/hard to verify"; "may be/have"; \
+"might be/have"; "possibly"; "perhaps"; "unclear"; "the reference \
+is/appears/seems correct" or any other verdict on the reference. Write \
+definitively around them (e.g. "excess shelter costs are deductible", not \
+"may be deducted"). Doubt \
+about the reference belongs ONLY in reference_suspect + \
+reference_bug_hypothesis, and requires a concrete contradiction: the \
+derivation conflicts with a specific statute, regulation, or published \
+parameter you can name, or contradicts its own arithmetic. Absent that, set \
+reference_suspect=false and diagnose from the reference as ground truth.
 
 failure_source meanings:
 - llm_error: the model reasoned or computed incorrectly (the usual case).
 - prompt_ambiguity: the question is genuinely ambiguous; a careful expert \
-could read it more than one way.
+could read it more than one way. Name the two readings.
 - reference_model_issue_fixed / reference_data_issue_fixed: the reference \
 value looks wrong (PolicyEngine logic / underlying data). Use with \
-reference_suspect=true.
+reference_suspect=true and a concrete contradiction.
 - parse_contract_failure: the model's answer was missing or unparseable, not a \
 substantive error.
-- needs_review: genuinely cannot tell.
+- needs_review: genuinely cannot tell; name precisely what information is \
+missing.
 
 Output ONLY the JSON verdict matching the schema. Do not run any commands; all \
 information you need is below.
@@ -274,7 +333,13 @@ def render_case_prompt(case: AuditCase) -> str:
     ]
     if case.reference_derivation:
         lines.append(
-            f"\nHOW POLICYENGINE DERIVED THE REFERENCE:\n{case.reference_derivation}"
+            "\nHOW POLICYENGINE DERIVED THE REFERENCE (generated from the "
+            f"engine's computation trace):\n{case.reference_derivation}"
+        )
+    if case.grounding:
+        lines.append(
+            "\nAUTHORITATIVE ENGINE FACTS (from the reference trace; every "
+            f"diagnosis must agree with these):\n{case.grounding}"
         )
     if case.question:
         lines.append(f"\nQUESTION SHOWN TO THE MODELS:\n{case.question}")
@@ -290,7 +355,11 @@ def render_case_prompt(case: AuditCase) -> str:
     return "\n".join(lines)
 
 
-def prepare_audit(country_dir: Path, audit_dir: Path) -> list[AuditCase]:
+def prepare_audit(
+    country_dir: Path,
+    audit_dir: Path,
+    grounding_lookup: dict[tuple[str, str], str] | None = None,
+) -> list[AuditCase]:
     """Write per-case prompts, the shared output schema, and a manifest.
 
     Layout under ``audit_dir``::
@@ -300,7 +369,7 @@ def prepare_audit(country_dir: Path, audit_dir: Path) -> list[AuditCase]:
         cases/<case_id>/prompt.md
         cases/<case_id>/verdict.json   (written later by the runner)
     """
-    cases = build_audit_cases(country_dir)
+    cases = build_audit_cases(country_dir, grounding_lookup=grounding_lookup)
     audit_dir.mkdir(parents=True, exist_ok=True)
     (audit_dir / "schema.json").write_text(json.dumps(AUDIT_OUTPUT_SCHEMA, indent=2))
     cases_root = audit_dir / "cases"
@@ -340,6 +409,39 @@ def prepare_audit(country_dir: Path, audit_dir: Path) -> list[AuditCase]:
                 verdict_path.unlink()
             prompt_path.write_text(new_prompt)
     return cases
+
+
+# --- Hedge detection -----------------------------------------------------------
+
+# Published diagnoses must be definitive. These patterns catch the judge
+# re-adjudicating the reference ("plausible", "not enough evidence") or
+# hedging its own diagnosis — both mean the verdict answered the wrong
+# question and must be re-judged, not shipped.
+HEDGE_PATTERNS = (
+    r"\bplausible\b",
+    r"not enough (?:concrete )?evidence",
+    r"insufficient (?:evidence|information)",
+    r"\bcannot\s+(?:be\s+)?(?:determine|verify|confirm|rule|tell)",
+    r"\bunable to (?:determine|verify|confirm|tell)",
+    r"difficult to (?:verify|confirm|determine)",
+    r"hard to (?:say|tell|verify)",
+    r"reference (?:is|looks|seems|appears) "
+    r"(?:plausible|correct|right|reasonable|accurate|sound|likely|fine)",
+    r"call the .{0,60}reference wrong",
+    r"treat the .{0,60}reference as",
+    r"\bmay (?:be|have)\b",
+    r"\bmight (?:be|have)\b",
+    r"\bpossibly\b",
+    r"\bperhaps\b",
+    r"\bunclear\b",
+)
+
+_HEDGE_RE = re.compile("|".join(HEDGE_PATTERNS), re.IGNORECASE)
+
+
+def is_hedged(text: object) -> bool:
+    """True when annotation text hedges instead of diagnosing."""
+    return bool(_HEDGE_RE.search(str(text or "")))
 
 
 # --- Verdict collection ------------------------------------------------------
@@ -395,10 +497,14 @@ def _row_failure_source(meta: dict, model: str, requested_source: str) -> str:
 def collect_audit(country_dir: Path, audit_dir: Path) -> dict[str, pd.DataFrame]:
     """Fold verdicts into the annotation schema.
 
-    Returns ``{"row": ..., "case": ..., "missing": ...}``. ``row`` and ``case``
-    match the committed annotation CSV columns, extended with ``rationale`` and
-    ``reference_suspect`` so the classifier's reasoning is preserved. ``missing``
-    lists cases whose verdict has not yet been produced (resumability).
+    Returns ``{"row": ..., "case": ..., "missing": ..., "hedged": ...}``.
+    ``row`` and ``case`` match the committed annotation CSV columns, extended
+    with ``rationale`` and ``reference_suspect`` so the classifier's reasoning
+    is preserved. ``missing`` lists cases whose verdict has not yet been
+    produced (resumability). ``hedged`` lists case ids whose diagnosis or
+    rationale hedges instead of diagnosing (see :data:`HEDGE_PATTERNS`) —
+    delete those ``verdict.json`` files and re-run the classifier rather than
+    shipping them.
     """
     manifest = _load_manifest(audit_dir)
     cases_root = audit_dir / "cases"
@@ -407,6 +513,7 @@ def collect_audit(country_dir: Path, audit_dir: Path) -> dict[str, pd.DataFrame]
     row_records: list[dict] = []
     case_records: list[dict] = []
     missing: list[str] = []
+    hedged: list[str] = []
 
     for case_id, meta in manifest.items():
         if meta.get("parse_failure_only"):
@@ -451,8 +558,14 @@ def collect_audit(country_dir: Path, audit_dir: Path) -> dict[str, pd.DataFrame]
         per_model = {
             str(m["model"]): m for m in verdict.get("models", []) if m.get("model")
         }
+        case_hedged = is_hedged(rationale)
         for model in meta["wrong_models"]:
             entry = per_model.get(model, {})
+            # The published per-model annotation is the model-specific
+            # diagnosis; the case rationale is only a fallback for verdicts
+            # predating the diagnosis field.
+            diagnosis = str(entry.get("diagnosis", "")).strip() or rationale
+            case_hedged = case_hedged or is_hedged(diagnosis)
             row_records.append(
                 {
                     "country": country,
@@ -468,9 +581,11 @@ def collect_audit(country_dir: Path, audit_dir: Path) -> dict[str, pd.DataFrame]
                         entry.get("failure_subtype", case_subtype)
                     ),
                     "reference_suspect": reference_suspect,
-                    "annotation": rationale,
+                    "annotation": diagnosis,
                 }
             )
+        if case_hedged:
+            hedged.append(case_id)
         case_records.append(
             {
                 "country": country,
@@ -512,4 +627,5 @@ def collect_audit(country_dir: Path, audit_dir: Path) -> dict[str, pd.DataFrame]
         "row": pd.DataFrame(row_records, columns=row_columns),
         "case": pd.DataFrame(case_records, columns=case_columns),
         "missing": pd.DataFrame({"case_id": missing}, columns=["case_id"]),
+        "hedged": pd.DataFrame({"case_id": hedged}, columns=["case_id"]),
     }

--- a/policybench/cli.py
+++ b/policybench/cli.py
@@ -546,6 +546,12 @@ def main():
         required=True,
         help="Output directory for case prompts, schema, and manifest",
     )
+    audit_prepare_parser.add_argument(
+        "--grounding-csv",
+        default=None,
+        help="Optional CSV (scenario_id, variable, grounding) of authoritative "
+        "engine facts rendered into matching case prompts",
+    )
 
     audit_collect_parser = subparsers.add_parser(
         "audit-collect",
@@ -557,6 +563,12 @@ def main():
         "--output-dir",
         default=None,
         help="Where to write annotation CSVs (default: the audit directory)",
+    )
+    audit_collect_parser.add_argument(
+        "--allow-hedged",
+        action="store_true",
+        help="Write CSVs even when some verdicts hedge instead of diagnosing "
+        "(default: refuse and list the hedged cases for re-judging)",
     )
 
     # Population weights
@@ -1215,7 +1227,21 @@ def main():
     elif args.command == "audit-prepare":
         from policybench.audit import prepare_audit
 
-        cases = prepare_audit(Path(args.country_dir), Path(args.audit_dir))
+        grounding_lookup = None
+        if args.grounding_csv:
+            import pandas as pd_module
+
+            grounding_df = pd_module.read_csv(args.grounding_csv)
+            grounding_lookup = {
+                (str(row.scenario_id), str(row.variable)): str(row.grounding)
+                for row in grounding_df.itertuples()
+                if str(row.grounding).strip()
+            }
+        cases = prepare_audit(
+            Path(args.country_dir),
+            Path(args.audit_dir),
+            grounding_lookup=grounding_lookup,
+        )
         print(
             f"Prepared {len(cases)} audit cases under {args.audit_dir}. "
             f"Run scripts/run_audit_codex.sh {args.audit_dir} to classify."
@@ -1226,6 +1252,15 @@ def main():
 
         country_dir = Path(args.country_dir)
         out = collect_audit(country_dir, Path(args.audit_dir))
+        hedged = out["hedged"]
+        if not hedged.empty and not args.allow_hedged:
+            for case_id in hedged["case_id"]:
+                print(f"HEDGED: {case_id}")
+            raise SystemExit(
+                f"{len(hedged)} verdicts hedge instead of diagnosing; delete "
+                f"their cases/<id>/verdict.json and re-run the classifier, or "
+                f"pass --allow-hedged to write anyway"
+            )
         output_dir = Path(args.output_dir) if args.output_dir else Path(args.audit_dir)
         output_dir.mkdir(parents=True, exist_ok=True)
         country = country_dir.name
@@ -1244,6 +1279,7 @@ def main():
         print(
             f"Collected {len(out['row'])} row / {len(out['case'])} case annotations "
             f"to {output_dir}; {len(out['missing'])} cases missing verdicts; "
+            f"{len(out['hedged'])} hedged; "
             f"{n_suspect} cases flag the PolicyEngine reference as suspect."
         )
 

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -16,6 +16,7 @@ from policybench.audit import (
     AUDIT_OUTPUT_SCHEMA,
     build_audit_cases,
     collect_audit,
+    is_hedged,
     parse_verdict,
     prepare_audit,
     render_case_prompt,
@@ -525,3 +526,119 @@ def test_parse_verdict_survives_brace_in_leading_prose(tmp_path: Path):
     parsed = parse_verdict(f)
     assert parsed is not None
     assert parsed["case_failure_source"] == "llm_error"
+
+
+def make_verdict(m1_diagnosis: str, m2_diagnosis: str, rationale: str) -> dict:
+    return {
+        "reference_suspect": False,
+        "reference_bug_hypothesis": "",
+        "case_failure_source": "llm_error",
+        "case_failure_subtype": "categorical_eligibility",
+        "rationale": rationale,
+        "models": [
+            {
+                "model": "m1",
+                "failure_source": "llm_error",
+                "failure_subtype": "thresholds_rates",
+                "diagnosis": m1_diagnosis,
+            },
+            {
+                "model": "m2",
+                "failure_source": "llm_error",
+                "failure_subtype": "categorical_eligibility",
+                "diagnosis": m2_diagnosis,
+            },
+        ],
+    }
+
+
+def test_collect_uses_per_model_diagnosis_for_row_annotation(
+    country_dir: Path, tmp_path: Path
+):
+    audit_dir = tmp_path / "audit"
+    cases = prepare_audit(country_dir, audit_dir)
+    s0 = next(c for c in cases if c.scenario_id == "s0")
+    verdict = make_verdict(
+        "Applied the net-income allotment formula without the earned income "
+        "deduction, overstating the benefit by $250.",
+        "Applied the 130% FPL gross income test to a household that is "
+        "categorically eligible under BBCE, concluding ineligibility.",
+        "Both models skipped the categorical-eligibility screen that "
+        "controls this household's SNAP outcome.",
+    )
+    (audit_dir / "cases" / s0.case_id / "verdict.json").write_text(json.dumps(verdict))
+
+    out = collect_audit(country_dir, audit_dir)
+    rows = out["row"]
+    m1 = rows[rows["model"] == "m1"].iloc[0]
+    m2 = rows[rows["model"] == "m2"].iloc[0]
+    assert m1["annotation"].startswith("Applied the net-income allotment")
+    assert m2["annotation"].startswith("Applied the 130% FPL gross income test")
+    assert out["case"].iloc[0]["case_annotation"].startswith("Both models skipped")
+    assert out["hedged"].empty
+
+
+def test_collect_flags_hedged_verdicts_for_rejudging(country_dir: Path, tmp_path: Path):
+    # The shipped 20260707c failure class: the judge answers "is the
+    # reference wrong?" instead of diagnosing the model.
+    audit_dir = tmp_path / "audit"
+    cases = prepare_audit(country_dir, audit_dir)
+    s0 = next(c for c in cases if c.scenario_id == "s0")
+    verdict = make_verdict(
+        "The reference is plausible under the stated PolicyEngine "
+        "derivation; there is not enough concrete evidence here to call "
+        "the PolicyEngine reference wrong.",
+        "The model may have used a stale threshold.",
+        "Hard to verify without more information.",
+    )
+    (audit_dir / "cases" / s0.case_id / "verdict.json").write_text(json.dumps(verdict))
+
+    out = collect_audit(country_dir, audit_dir)
+    assert list(out["hedged"]["case_id"]) == [s0.case_id]
+
+
+def test_is_hedged_separates_verdict_voice_from_legal_optionality():
+    # Reference-adjudication and self-doubt: rejected.
+    assert is_hedged(
+        "The reference is plausible under the stated PolicyEngine derivation"
+    )
+    assert is_hedged("There is not enough concrete evidence to call it wrong")
+    assert is_hedged("The model may have applied 2023 thresholds")
+    assert is_hedged("It is unclear which pathway the model used")
+    assert is_hedged("We cannot determine the exact computation")
+    # Definitive diagnosis, including legal-optionality phrasing: allowed.
+    assert not is_hedged(
+        "Treated the 138% FPL MAGI limit as the only Medicaid pathway and "
+        "never applied the aged/disabled income test, which deducts the "
+        "Medicare Part B premium from countable income."
+    )
+    assert not is_hedged("Excess shelter costs are deductible; the model omitted them.")
+    assert not is_hedged("")
+    assert not is_hedged(None)
+
+
+def test_prompt_treats_reference_as_verified_and_demands_diagnosis(
+    country_dir: Path,
+):
+    case = next(c for c in build_audit_cases(country_dir) if c.scenario_id == "s0")
+    prompt = render_case_prompt(case)
+    assert "Treat the reference and its derivation as correct" in prompt
+    assert "diagnosis" in prompt
+    assert "mechanically rejected" in prompt
+    assert "concrete contradiction" in prompt
+
+
+def test_grounding_lookup_renders_engine_facts_block(country_dir: Path):
+    lookup = {("s0", "snap"): "- medicaid_category: SENIOR_OR_DISABLED\n- age: 67"}
+    cases = build_audit_cases(country_dir, grounding_lookup=lookup)
+    grounded = next(c for c in cases if c.scenario_id == "s0")
+    bare = next(c for c in cases if c.scenario_id == "s1")
+    assert "AUTHORITATIVE ENGINE FACTS" in render_case_prompt(grounded)
+    assert "SENIOR_OR_DISABLED" in render_case_prompt(grounded)
+    assert "AUTHORITATIVE ENGINE FACTS" not in render_case_prompt(bare)
+
+
+def test_schema_requires_per_model_diagnosis():
+    items = AUDIT_OUTPUT_SCHEMA["properties"]["models"]["items"]
+    assert "diagnosis" in items["properties"]
+    assert "diagnosis" in items["required"]


### PR DESCRIPTION
Max flagged the live annotation for [scenario_031 head_medicaid_eligible ~ gpt-5.5](https://policybench.org/?scenario=scenario_031&cell=head_medicaid_eligible~gpt-5.5): "The reference is plausible under the stated PolicyEngine derivation… There is not enough concrete evidence here to call the PolicyEngine reference wrong." The judge is answering "is the reference wrong?" instead of "why did this model miss?"

## Root cause
- The audit prompt's first instruction was to adjudicate the reference, so the free-text `rationale` came out as a hedged reference verdict — 227/636 shipped cases (36%) contain "plausible", "not enough evidence", or similar.
- The verdict schema had no per-model text field, so all wrong models in a case shared the case rationale verbatim as their published annotation (100% of cases).

## Fix
- **Per-model `diagnosis` (required)**: 1–3 definitive sentences naming the exact rule, eligibility pathway, deduction, threshold, or computation step that model missed or misapplied, grounded in its own stated reasoning (or, absent reasoning, in what its answer implies). This becomes the published row annotation.
- **Prompt reframe**: the reference value and derivation are generated from the engine's computation trace and have survived adversarial review (35 wrong-reference hypotheses adjudicated against primary sources; the 4 real bugs found were fixed before this run) — treat them as correct. Hedge phrasings are listed and mechanically rejected. Genuine reference doubt goes only in `reference_suspect`/`reference_bug_hypothesis` and requires a concrete contradiction with a nameable statute/regulation/parameter — the same evidentiary bar the #91/#107 triages applied.
- **Grounding**: `audit-prepare --grounding-csv` renders an AUTHORITATIVE ENGINE FACTS block (e.g. `medicaid_category: SENIOR_OR_DISABLED` from the reference trace) into matching case prompts, mirroring the narrative generator's grounding fix.
- **Enforcement**: `collect_audit` returns hedged case ids via `HEDGE_PATTERNS`/`is_hedged`, and `audit-collect` refuses to write annotation CSVs while any verdict hedges (`--allow-hedged` to override). Hedged verdicts get deleted and re-judged, not shipped.

Content-aware resumability already invalidates every stored verdict when prompts change, so re-running `audit-prepare` + the Codex sweep re-judges all 636 substantive cases under the new contract. The republish will follow as a separate data PR once the re-audit completes and passes the hedge gate.

Six new tests lock the contract (diagnosis→row annotation, hedge detection on the exact shipped failure text, verified-reference prompt language, grounding block, schema requirement).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
