### PR TITLE
Temporarily hide leaderboard costs

### DIFF
--- a/app/src/components/ModelLeaderboard.tsx
+++ b/app/src/components/ModelLeaderboard.tsx
@@ -58,14 +58,6 @@ function accColor(pct: number): "success" | "primary" | "warning" | "danger" {
   return "danger";
 }
 
-// Per-household cost, always to the tenth of a cent so every model reads with
-// the same precision. Values span ~$0.002 to ~$0.29, so two decimals would
-// round the cheapest models to $0.00; three keeps them consistent and legible.
-function fmtCost(usd: number | undefined, symbol: string): string {
-  if (usd == null || !Number.isFinite(usd)) return "—";
-  return `${symbol}${usd.toFixed(3)}`;
-}
-
 export default function ModelLeaderboard({
   data,
   selectedView,
@@ -296,15 +288,8 @@ export default function ModelLeaderboard({
           <div role="columnheader" className="col-span-1">
             #
           </div>
-          <div role="columnheader" className="col-span-7">
+          <div role="columnheader" className="col-span-9">
             Model
-          </div>
-          <div
-            role="columnheader"
-            className="col-span-2 text-right"
-            title="Estimated cost to run one household's full set of outputs, no tools (batch runs priced at standard synchronous rates)"
-          >
-            Cost / household
           </div>
           <div role="columnheader" className="col-span-2 text-right">
             {scoringMode === "exact"
@@ -356,9 +341,6 @@ export default function ModelLeaderboard({
                         {MODEL_LABELS[m.model] || m.model}
                       </Link>
                     </div>
-                    <div className="mt-1.5 pl-[26px] font-[family-name:var(--font-mono)] text-[11px] text-text-muted">
-                      {fmtCost(m.costPerHousehold, currencySymbol)} per household
-                    </div>
                   </div>
 
                   <Badge
@@ -377,7 +359,7 @@ export default function ModelLeaderboard({
                   </span>
                 </div>
 
-                <div className="col-span-7 flex min-w-0 items-center gap-2.5">
+                <div className="col-span-9 flex min-w-0 items-center gap-2.5">
                   <ProviderMark
                     provider={getProviderForModel(m.model)}
                     size={14}
@@ -390,18 +372,6 @@ export default function ModelLeaderboard({
                     {MODEL_LABELS[m.model] || m.model}
                   </Link>
                 </div>
-
-                <div
-                  className="col-span-2 text-right font-[family-name:var(--font-mono)] text-sm text-text-secondary"
-                  title={
-                    m.costUsd != null
-                      ? `${currencySymbol}${m.costUsd.toFixed(2)} total · ${fmtCost(m.costPerHousehold, currencySymbol)} per household`
-                      : "Cost not recorded for this model"
-                  }
-                >
-                  {fmtCost(m.costPerHousehold, currencySymbol)}
-                </div>
-
 
                 <div className="col-span-2 text-right">
                   <Badge

--- a/app/tests/modelLeaderboard.test.ts
+++ b/app/tests/modelLeaderboard.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, test } from "bun:test";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import ModelLeaderboard from "../src/components/ModelLeaderboard";
+import type { BenchData } from "../src/types";
+
+function makeBench(): BenchData {
+  return {
+    country: "us",
+    scenarios: {},
+    modelStats: [
+      {
+        model: "gpt-5.5",
+        condition: "no_tools",
+        score: 91.2,
+        exact: 87.3,
+        n: 100,
+        nParsed: 100,
+        costUsd: 9876.54,
+        costPerHousehold: 98.765,
+      },
+    ],
+    programStats: [],
+    heatmap: [],
+    scenarioPredictions: {},
+    failureModes: { programs: [], households: [] },
+  };
+}
+
+describe("ModelLeaderboard", () => {
+  test("given cost data, when rendered, then keeps costs out of the public leaderboard", () => {
+    // Given a benchmark row that retains its internal run-cost metadata.
+    const data = makeBench();
+
+    // When the public leaderboard is rendered.
+    const markup = renderToStaticMarkup(
+      createElement(ModelLeaderboard, {
+        data,
+        selectedView: "us",
+        dashboard: { countries: { us: data } },
+        programOptions: [],
+        activeProgramIds: new Set<string>(),
+        activeProgramSummary: "All programs",
+        onResetPrograms: () => {},
+        onToggleProgram: () => {},
+        onSelectOnlyProgram: () => {},
+      }),
+    );
+
+    // Then model results remain visible without either cost label or value.
+    expect(markup).toContain("GPT-5.5");
+    expect(markup).toContain("87.3%");
+    expect(markup).not.toContain("Cost / household");
+    expect(markup).not.toContain("per household");
+    expect(markup).not.toContain("$98.765");
+    expect(markup).not.toContain("$9876.54");
+  });
+});


### PR DESCRIPTION
## Summary

- remove the public cost-per-household column from desktop and mobile leaderboards
- retain cost metadata in benchmark artifacts and TypeScript types for reconciliation
- add a server-rendered regression test proving cost labels and values stay out of the leaderboard

## Why

The current cost values mix billing modes, provenance, serving recipes, and retry accounting. In particular, replaced retry or repair rows can omit prior attempt spend. Showing the values together therefore implies a comparability the data does not yet support.

Restoration requirements are tracked in #118, including cumulative attempt accounting and a fresh GPT-5.5 serving-recipe validation.

## Validation

- bun test tests (85 passed)
- bunx eslint src/components/ModelLeaderboard.tsx tests/modelLeaderboard.test.ts --max-warnings=0
- bun run build
